### PR TITLE
Split offers and request in profile

### DIFF
--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -515,9 +515,11 @@ function initialize_reset_password_form() {
 
 function initialize_profile_view(profile_id) {
   $('#load-more-listings a').on("click", function() {
-    var request_path = $(this).data().url;
+    var buttonData = $(this).data()
+    var request_path = buttonData.url;
+    var containerIdTag = buttonData.containeridtag;
     $.get(request_path, function(data) {
-      $('#profile-listings-list').html(data);
+      $(containerIdTag).html(data);
     });
     return false;
   });

--- a/app/assets/stylesheets/views/_people.scss
+++ b/app/assets/stylesheets/views/_people.scss
@@ -28,7 +28,6 @@ $profile-pic-gutter-mobile: lines(0.5);
 
 .people-show-closed-link {
   font-size: 13px;
-  margin-left: lines(0.5);
 }
 
 .profile-action-buttons-desktop {

--- a/app/indices/listing_index.rb
+++ b/app/indices/listing_index.rb
@@ -7,14 +7,15 @@ if APP_CONFIG.use_thinking_sphinx_indexing.to_s.casecmp("true") == 0
     # be explicit.
     set_property :utf8? => true
 
-    # limit to open listings
-    where "listings.open = '1' AND listings.deleted = '0' AND (listings.valid_until IS NULL OR listings.valid_until > now()) AND listings.state = 'approved'"
+    # limit to non-deleted listings
+    where "listings.deleted = '0' AND (listings.valid_until IS NULL OR listings.valid_until > now()) AND listings.state = 'approved'"
 
     # fields
     indexes title
     indexes description
     indexes custom_field_values(:text_value), :as => :custom_text_fields
     indexes origin_loc.google_address
+    indexes author_id
 
     # attributes
     has id, :as => :listing_id # id didn't work without :as aliasing
@@ -26,6 +27,7 @@ if APP_CONFIG.use_thinking_sphinx_indexing.to_s.casecmp("true") == 0
     has community_id
     has custom_dropdown_field_values.selected_options.id, :as => :custom_dropdown_field_options, :type => :integer, :multi => true
     has custom_checkbox_field_values.selected_options.id, :as => :custom_checkbox_field_options, :type => :integer, :multi => true
+    has open
 
     set_property :enable_star => true
 
@@ -34,6 +36,5 @@ if APP_CONFIG.use_thinking_sphinx_indexing.to_s.casecmp("true") == 0
       :category => 8,
       :description => 3
     }
-
   end
 end

--- a/app/presenters/listings_person_presenter.rb
+++ b/app/presenters/listings_person_presenter.rb
@@ -11,7 +11,8 @@ class ListingsPersonPresenter
       author_id: @person.id,
       include_closed: include_closed,
       page: 1,
-      per_page: @per_page
+      per_page: @per_page,
+      listing_shape_ids: ([params[:listing_shape_id].to_i] if params[:listing_shape_id])
     }
 
     @listings =

--- a/app/services/listing_index_service/data_types.rb
+++ b/app/services/listing_index_service/data_types.rb
@@ -27,9 +27,9 @@ module ListingIndexService::DataTypes
     [:listing_shape_ids, :array, :optional],
     [:price_cents, :range, :optional],
     [:fields, :array, default: []],
-    [:author_id, :string],
+    [:author_id, :string, default: ''],
     [:include_closed, :to_bool, default: false],
-    [:locale, :symbol, :optional]
+    [:locale, :symbol, :optional],
   )
 
   AvatarImage = EntityUtils.define_builder(

--- a/app/services/person/show_service.rb
+++ b/app/services/person/show_service.rb
@@ -75,10 +75,11 @@ class Person::ShowService
   def listings_per_shape
     return @listings_by_shape if defined?(@listings_by_shape)
     @listings_by_shape = listings.each_with_object({}) do |item, hash|
-      if hash[item.listing_shape_id]
-        hash[item.listing_shape_id].push(item)
+      listing_shape = ListingShape.find_by(id: item.listing_shape_id)
+      if hash[listing_shape]
+        hash[listing_shape].push(item)
       else
-        hash[item.listing_shape_id] = [item]
+        hash[listing_shape] = [item]
       end
     end
   end

--- a/app/services/person/show_service.rb
+++ b/app/services/person/show_service.rb
@@ -72,6 +72,17 @@ class Person::ShowService
       }.data
   end
 
+  def listings_per_shape
+    return @listings_by_shape if defined?(@listings_by_shape)
+    @listings_by_shape = listings.each_with_object({}) do |item, hash|
+      if hash[item.listing_shape_id]
+        hash[item.listing_shape_id].push(item)
+      else
+        hash[item.listing_shape_id] = [item]
+      end
+    end
+  end
+
   def admin?
     current_user&.has_admin_rights?(community)
   end

--- a/app/views/listings/_profile_listings.haml
+++ b/app/views/listings/_profile_listings.haml
@@ -2,10 +2,10 @@
   .people-fluid-thumbnail-grid#profile-listings-list
     = render :partial => "people/grid_item", :collection => listings, :as => :listing
 
-- if listings.length > limit
+- if listings.total_entries > limit
   .people-load-more-listings-container
     #load-more-listings
       - if current_user?(person) && params[:show_closed]
-        = link_to t("people.show.show_all_listings"), "#", :data => { :url => person_listings_url(person, :show_closed => true) }
+        = link_to t("people.show.show_all_listings"), "#", :data => { :url => person_listings_url(person, :show_closed => true, :listing_shape_id => listing_shape.id), :containeridtag => container_id_tag }
       - else
-        = link_to t("people.show.show_all_open_listings"), "#", :data => { :url => person_listings_url(person) }
+        = link_to t("people.show.show_all_open_listings"), "#", :data => { :url => person_listings_url(person, :listing_shape_id => listing_shape.id), :containeridtag => container_id_tag }

--- a/app/views/listings/_profile_listings.haml
+++ b/app/views/listings/_profile_listings.haml
@@ -2,7 +2,7 @@
   .people-fluid-thumbnail-grid#profile-listings-list
     = render :partial => "people/grid_item", :collection => listings, :as => :listing
 
-- if listings.total_entries > limit
+- if listings.length > limit
   .people-load-more-listings-container
     #load-more-listings
       - if current_user?(person) && params[:show_closed]

--- a/app/views/people/show.haml
+++ b/app/views/people/show.haml
@@ -58,13 +58,13 @@
         .row
           %h2.people-header
             - if current_user?(person) && params[:show_closed]
-              = pluralize(listings_array.length, "#{t(listing_shape.name_tr_key).downcase} #{t(".listing")}", "#{t(listing_shape.name_tr_key).downcase} #{t(".listings")}")
+              = pluralize(listings_array.total_entries, "#{t(listing_shape.name_tr_key).downcase} #{t(".listing")}", "#{t(listing_shape.name_tr_key).downcase} #{t(".listings")}")
             - else
-              = pluralize(listings_array.length, "#{t(".open")} #{t(listing_shape.name_tr_key).downcase} #{t(".listing")}", "#{t(".open")} #{t(listing_shape.name_tr_key).downcase} #{t(".listings")}")
+              = pluralize(listings_array.total_entries, "#{t(".open")} #{t(listing_shape.name_tr_key).downcase} #{t(".listing")}", "#{t(".open")} #{t(listing_shape.name_tr_key).downcase} #{t(".listings")}")
                
-        #profile-listings-list
+        %div{id: "profile-listings-list-#{listing_shape.id}"}
           - limit = 6
-          = render :partial => 'listings/profile_listings', :locals => {person: person, limit: limit, listings: listings_array}
+          = render :partial => 'listings/profile_listings', :locals => {person: person, limit: limit, listings: listings_array, container_id_tag: "#profile-listings-list-#{listing_shape.id}", listing_shape: listing_shape}
     
     - else
       .row

--- a/app/views/people/show.haml
+++ b/app/views/people/show.haml
@@ -48,26 +48,32 @@
                 - else
                   %span.people-custom-fields-value
                     = custom_field_value.display_value
-
     .row
-      %h2.people-header
-        - if @service.listings.total_entries > 0
-          - if current_user?(person) && params[:show_closed]
-            = pluralize(@service.listings.total_entries, t(".listing"), t(".listings"))
-          - else
-            = pluralize(@service.listings.total_entries, t(".open_listing"), t(".open_listings"))
-        - else
+      %span.people-show-closed-link
+        - if current_user?(person)
+          = link_to t("people.profile_listings.manage_listings"), listings_person_settings_path(person.username)
+    
+    - if @service.listings.total_entries > 0
+      - @service.listings_per_shape.each do |listing_shape, listings_array|
+        .row
+          %h2.people-header
+            - if current_user?(person) && params[:show_closed]
+              = pluralize(listings_array.length, "#{t(listing_shape.name_tr_key).downcase} #{t(".listing")}", "#{t(listing_shape.name_tr_key).downcase} #{t(".listings")}")
+            - else
+              = pluralize(listings_array.length, "#{t(".open")} #{t(listing_shape.name_tr_key).downcase} #{t(".listing")}", "#{t(".open")} #{t(listing_shape.name_tr_key).downcase} #{t(".listings")}")
+               
+        #profile-listings-list
+          - limit = 6
+          = render :partial => 'listings/profile_listings', :locals => {person: person, limit: limit, listings: listings_array}
+    
+    - else
+      .row
+        %h2.people-header
           - if current_user?(person) && params[:show_closed]
             = t(".no_listings")
           - else
             = t(".no_open_listings")
-        %span.people-show-closed-link
-          - if current_user?(person)
-            = link_to t("people.profile_listings.manage_listings"), listings_person_settings_path(person.username)
 
-    #profile-listings-list
-      - limit = 6
-      = render :partial => 'listings/profile_listings', :locals => {person: person, limit: limit, listings: @service.listings}
 
     - if @service.community.follow_in_use?
       = render :partial => "followed_people", :locals => { person: person, followed_people: @service.followed_people, limit: 6 }

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -297,7 +297,8 @@ default: &default_settings
   external_plan_service_secret:
   external_plan_service_login_url:
 
-  # External search service connection
+  # External search service connection only for hosted version, not opensource
+  # https://www.sharetribe.com/community/t/external-search-in-use-problem/1215
   external_search_in_use: false
   external_search_url:
   external_search_apikey:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2766,6 +2766,7 @@ en:
       what_are_these: "What are these?"
       review: "received review"
       reviews: "received reviews"
+      open: "Open"
       listing: listing
       listings: listings
       open_listing: "open listing"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2766,7 +2766,7 @@ en:
       what_are_these: "What are these?"
       review: "received review"
       reviews: "received reviews"
-      open: "Open"
+      open: "open"
       listing: listing
       listings: listings
       open_listing: "open listing"

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -130,6 +130,9 @@ describe HomepageController, type: :controller do
 
     it 'shows approved listing' do
       listing
+      mock_search_result = [listing]
+      allow(mock_search_result).to receive(:total_entries).and_return(1)
+      allow(Listing).to receive(:search).and_return(mock_search_result)
       get :index
       listings = assigns(:listings)
       expect(listings.count).to eq 1

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -220,6 +220,10 @@ describe ListingsController, type: :controller do
 
       @request.host = "#{@c1.ident}.lvh.me"
       @request.env[:current_marketplace] = @c1
+
+      mock_search_result = [@l2, @l1]
+      allow(mock_search_result).to receive(:total_entries).and_return(2)
+      allow(Listing).to receive(:search).and_return(mock_search_result)
     end
 
     it "lists the most recent listings in order" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -100,6 +100,7 @@ FactoryGirl.define do
     phone_number "0000-123456"
     username
     password "testi"
+    deleted 0
 
     has_many :emails do |person|
       FactoryGirl.build(:email, person: person)

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -240,7 +240,7 @@ describe PersonMailer, type: :mailer do
       confirmed_transaction.update_column(:payment_gateway, 'stripe')
       confirmed_transaction.reload
       email = PersonMailer.transaction_confirmed(confirmed_transaction, community)
-      expect(email.body).to have_text("Proto T has marked the order <b>Sledgehammer</b> completed. The payment for this transaction has now been released. You can now give feedback to Proto.")
+      expect(email.body).to have_text("Proto has marked the order <b>Sledgehammer</b> completed. The payment for this transaction has now been released. You can now give feedback to Proto.")
     end
   end
 end

--- a/spec/services/person/show_service_spec.rb
+++ b/spec/services/person/show_service_spec.rb
@@ -13,10 +13,14 @@ describe Person::ShowService do
   end
 
   let(:listing_shape1) do
-    FactoryGirl.create(:listing_shape, community_id: community.id)
+    FactoryGirl.create(:listing_shape, community_id: community.id,
+                                       name: 'shape1'
+                                       )
   end
   let(:listing_shape2) do
-    FactoryGirl.create(:listing_shape, community_id: community.id)
+    FactoryGirl.create(:listing_shape, community_id: community.id,
+                                       name: 'shape2'
+                                       )
   end
 
   let(:listing1) do
@@ -47,15 +51,15 @@ describe Person::ShowService do
   end
 
   describe "#listings_per_shape" do
-    it 'listing_shape_ids as keys of returned hash' do
+    it 'listing_names as keys of returned hash' do
       allow(subject).to receive(:listings).and_return([listing1, listing2, listing3])
-      expect(subject.listings_per_shape.keys).to eq([listing_shape1.id, listing_shape2.id])
+      expect(subject.listings_per_shape.keys).to eq([listing_shape1, listing_shape2])
     end
 
-    it 'sorts listings by listing_shape_id' do
+    it 'sorts listings by listing_name' do
       allow(subject).to receive(:listings).and_return([listing1, listing2, listing3])
-      expect(subject.listings_per_shape[listing_shape1.id]).to eq([listing1, listing2])
-      expect(subject.listings_per_shape[listing_shape2.id]).to eq([listing3])
+      expect(subject.listings_per_shape[listing_shape1]).to eq([listing1, listing2])
+      expect(subject.listings_per_shape[listing_shape2]).to eq([listing3])
     end
   end
 end

--- a/spec/services/person/show_service_spec.rb
+++ b/spec/services/person/show_service_spec.rb
@@ -51,15 +51,18 @@ describe Person::ShowService do
   end
 
   describe "#listings_per_shape" do
-    it 'listing_names as keys of returned hash' do
-      allow(subject).to receive(:listings).and_return([listing1, listing2, listing3])
+    it 'listing_shapes as keys of returned hash' do
+      allow(ListingShape).to receive(:where).and_return([listing_shape1, listing_shape2])
+      allow(subject).to receive(:listings_search)
       expect(subject.listings_per_shape.keys).to eq([listing_shape1, listing_shape2])
     end
 
     it 'sorts listings by listing_name' do
-      allow(subject).to receive(:listings).and_return([listing1, listing2, listing3])
-      expect(subject.listings_per_shape[listing_shape1]).to eq([listing1, listing2])
-      expect(subject.listings_per_shape[listing_shape2]).to eq([listing3])
+      allow(ListingShape).to receive(:where).and_return([listing_shape1, listing_shape2])
+      allow(subject).to receive(:listings_search).and_return([listing1, listing2], [listing3])
+      result = subject.listings_per_shape
+      expect(result[listing_shape1]).to eq([listing1, listing2])
+      expect(result[listing_shape2]).to eq([listing3])
     end
   end
 end

--- a/spec/services/person/show_service_spec.rb
+++ b/spec/services/person/show_service_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Person::ShowService do
+
+  let(:community) { FactoryGirl.create(:community) }
+
+  let(:seller) do
+    FactoryGirl.create(:person, member_of: community,
+                                given_name: 'Sherry',
+                                family_name: 'Rivera',
+                                display_name: 'Sky caterpillar'
+                      )
+  end
+
+  let(:listing_shape1) do
+    FactoryGirl.create(:listing_shape, community_id: community.id)
+  end
+  let(:listing_shape2) do
+    FactoryGirl.create(:listing_shape, community_id: community.id)
+  end
+
+  let(:listing1) do
+    FactoryGirl.create(:listing, community_id: community.id,
+                                 title: 'Apple cake',
+                                 author: seller,
+                                 listing_shape_id: listing_shape1.id
+                                 )
+  end
+  let(:listing2) do
+    FactoryGirl.create(:listing, community_id: community.id,
+                                 title: 'Bannana Cake',
+                                 author: seller,
+                                 listing_shape_id: listing_shape1.id
+                                 )
+  end
+  let(:listing3) do
+    FactoryGirl.create(:listing, community_id: community.id,
+                                 title: 'Pineapple cake',
+                                 author: seller,
+                                 listing_shape_id: listing_shape2.id
+                                 )
+  end
+
+  let(:subject) do
+    params = {'username': seller.username, 'show_closed': false}
+    Person::ShowService.new(community: community, params: params, current_user: seller)
+  end
+
+  describe "#listings_per_shape" do
+    it 'listing_shape_ids as keys of returned hash' do
+      allow(subject).to receive(:listings).and_return([listing1, listing2, listing3])
+      expect(subject.listings_per_shape.keys).to eq([listing_shape1.id, listing_shape2.id])
+    end
+
+    it 'sorts listings by listing_shape_id' do
+      allow(subject).to receive(:listings).and_return([listing1, listing2, listing3])
+      expect(subject.listings_per_shape[listing_shape1.id]).to eq([listing1, listing2])
+      expect(subject.listings_per_shape[listing_shape2.id]).to eq([listing3])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ prefork = lambda {
   require 'rspec/rails'
   require "email_spec"
   require './spec/support/webmock'
+  require 'sphinx_helper'
 
   # Requires supporting files with custom matchers and macros, etc,
   # in ./support/ and its subdirectories.
@@ -59,6 +60,13 @@ prefork = lambda {
     config.mock_with :rspec
     config.include Devise::Test::ControllerHelpers, type: :controller
     config.include SpecUtils
+    config.use_transactional_fixtures = false
+    config.include SphinxHelpers
+
+    config.before(:suite) do
+      ThinkingSphinx::Test.init
+      ThinkingSphinx::Test.start_with_autostop
+    end
 
     Timecop.safe_mode = true
 

--- a/spec/sphinx_helper.rb
+++ b/spec/sphinx_helper.rb
@@ -1,0 +1,11 @@
+module SphinxHelpers
+  def index
+    ThinkingSphinx::Test.index
+    # Wait for Sphinx to finish loading in the new index files.
+    sleep 0.25 until index_finished?
+  end
+
+  def index_finished?
+    Dir[Rails.root.join(ThinkingSphinx::Test.config.indices_location, '*.{new,tmp}*')].empty?
+  end
+end


### PR DESCRIPTION
Write issue: https://www.wrike.com/open.htm?id=436108257

Overview: 
- Update ThinkingSphinx search engine to allow for listing search by author_id, open, and listing_shape_id. 
- Add method to listing show service to return listings by listing_shape. 
- Edit profile views to split listings by listing shape. 
- Fix RSpec

Commands on deploy:
- RAILS_ENV=<your-env> bundle exec rake ts:rebuild 