### PR TITLE
Change all dignity references to gigfunding

### DIFF
--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -4,7 +4,7 @@ default: &default_settings
   # If you are running on localhost, you can write here "lvh.me:3000" (which redirects to localhost port 3000)
   # The community subdomains will be added to this top domain.
   # NOTE: Do not include http(s) here, or subdomains, just the top level domain, like "sharetribe.com" for example
-  domain: "dignityplatform.org"
+  domain: "gigfunding.org"
 
   # A comma separated string of trusted proxies. If you host your
   # application behind proxies this configuration allows
@@ -180,7 +180,7 @@ default: &default_settings
   mail_delivery_method: "letter_opener"
 
   # This will be the from field in the mails sent from Sharetribe
-  sharetribe_mail_from_address: "marketplace@dignityplatform.org"
+  sharetribe_mail_from_address: "marketplace@gigfunding.org"
 
   # The address where the notifications of feedbacks from Sharetribe UI are sent
   feedback_mailer_recipients:  'admins@example.com'

--- a/testfile
+++ b/testfile
@@ -37,7 +37,7 @@ script.src = "https://checkout.stripe.com/checkout.js";
 script.setAttribute("class", "stripe-button");
 script.setAttribute("data-key", "pk_test_gJIeYpuvZc56uI22j5yr7h3s");
 script.setAttribute("data-amount", totalAmount );
-script.setAttribute("data-name", "Dignity Platform");
+script.setAttribute("data-name", "Gigfunding");
 script.setAttribute("data-description", "Task");
 script.setAttribute("data-image", "image.png");
 script.setAttribute("data-label", "Pay for this request");


### PR DESCRIPTION
Change all references of 'dignityplatform.org' to 'gigfunding.org' 

Ensure host is setup to receive requests on new domain and marketplace@gigfunding.org is working before applying app changes