### PR TITLE
#537799489 - Fix email validation messages for new signups

### DIFF
--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -342,7 +342,7 @@ function initialize_give_feedback_form(locale, grade_error_message, text_error_m
   });
 }
 
-function initialize_signup_form(locale, email_in_use_message, invalid_invitation_code_message, name_required, invitation_required) {
+function initialize_signup_form(locale, email_already_in_use_message, invalid_invitation_code_message, name_required, invitation_required) {
   $('#help_invitation_code_link').click(function(link) {
     //link.preventDefault();
     $('#help_invitation_code').lightbox_me({centered: true, zIndex: 1000000 });
@@ -366,17 +366,17 @@ function initialize_signup_form(locale, email_in_use_message, invalid_invitation
       }
     },
     rules: {
-      "person[given_name]": {required: name_required, maxlength: 30},
-      "person[family_name]": {required: name_required, maxlength: 30},
-      "person[email]": {required: true, email_remove_spaces: true, remote: "/people/check_email_availability_and_validity"},
-      "person[terms]": "required",
+      "person[given_name]": { required: name_required, maxlength: 30 },
+      "person[family_name]": { required: name_required, maxlength: 30 },
+      "person[email]": { required: true, email_remove_spaces: true, remote: "/people/check_email_availability_and_validity" },
+      "person[terms]": { required: true },
       "person[password]": { required: true, minlength: 4 },
       "person[password2]": { required: true, minlength: 4, equalTo: "#person_password1" },
-      "invitation_code": {required: invitation_required, remote: "/people/check_invitation_code"}
+      "invitation_code": { required: invitation_required, remote: "/people/check_invitation_code" }
     },
     messages: {
-      "person[email]": { remote: email_in_use_message, email_remove_spaces: $.validator.messages.email },
-      "invitation_code": { remote: invalid_invitation_code_message }
+      "person[email]": { remote: `${email_already_in_use_message}` },
+      "invitation_code": { remote: `${invalid_invitation_code_message}` }
     },
     onkeyup: false, //Only do validations when form focus changes to avoid exessive ASI calls
     submitHandler: function(form) {

--- a/app/views/community_memberships/pending_consent.haml
+++ b/app/views/community_memberships/pending_consent.haml
@@ -1,5 +1,5 @@
 - content_for :javascript do
-  initialize_pending_consent_form("#{t("people.new.email_is_in_use_or_not_allowed")}",#{invite_only}, "#{t("people.new.invalid_invitation_code")}");
+  initialize_pending_consent_form("#{t("people.new.email_is_in_use_or_not_allowed")}", #{invite_only}, "#{t("people.new.invalid_invitation_code")}");
 
 - content_for :title_header do
   %h1= t('community_memberships.new.join_community', community: @current_community.name(I18n.locale))

--- a/app/views/people/new.haml
+++ b/app/views/people/new.haml
@@ -1,5 +1,5 @@
 - content_for :javascript do
-  initialize_signup_form("#{I18n.locale}","#{email_not_accepted_message}", "#{t("people.new.invalid_invitation_code")}", #{@current_community.real_name_required?}, #{@current_community.join_with_invite_only?} );
+  initialize_signup_form("#{I18n.locale}", "#{email_not_accepted_message}", "#{t("people.new.invalid_invitation_code")}", #{@current_community.real_name_required?}, #{@current_community.join_with_invite_only?} );
 
 - content_for :title_header do
   %h1= t('.sign_up')


### PR DESCRIPTION
**Wrike task**: https://www.wrike.com/open.htm?id=537799489
**Issue:** Fix email validation messages which are returning 'true' production when the email is already in use.
**Changes:** Edit initialize_signup_form validator method fixing some syntax errors, removing un-necessary messages, and string interpolating messages instead of returning arguments directly.
**On deploy:** Recompile assets due to changes to javascript ```RAILS_ENV=production bundle exec rails assets:precompile``` 
