### PR TITLE
#474971716 - Fix broken image links in emails

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -11,4 +11,7 @@ module EmailHelper
     end
   end
 
+  def email_image_url(image_url)
+    URI.join(ActionController::Base.asset_host, image_url).to_s
+  end
 end

--- a/app/mailers/community_mailer.rb
+++ b/app/mailers/community_mailer.rb
@@ -11,6 +11,8 @@ class CommunityMailer < ActionMailer::Base
 
   require "truncate_html"
 
+  add_template_helper(EmailHelper)
+
   # This task is expected to be run with daily or hourly scheduling
   # It looks through all users and send email to those who want it now
   def self.deliver_community_updates

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -16,6 +16,7 @@ class PersonMailer < ActionMailer::Base
   default :from => APP_CONFIG.sharetribe_mail_from_address
   layout 'email'
 
+  add_template_helper(EmailHelper)
   add_template_helper(EmailTemplateHelper)
 
   def conversation_status_changed(transaction, community)

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -16,6 +16,7 @@ class TransactionMailer < ActionMailer::Base
   default :from => APP_CONFIG.sharetribe_mail_from_address
   layout 'email'
 
+  add_template_helper(EmailHelper)
   add_template_helper(EmailTemplateHelper)
 
   def transaction_preauthorized(transaction)
@@ -27,6 +28,7 @@ class TransactionMailer < ActionMailer::Base
       else
         transaction.author
     end
+    
     set_up_layout_variables(recipient, transaction.community)
     with_locale(recipient.locale, transaction.community.locales.map(&:to_sym), transaction.community.id) do
 

--- a/app/views/community_mailer/_community_update_listing.html.haml
+++ b/app/views/community_mailer/_community_update_listing.html.haml
@@ -7,7 +7,7 @@
             %tr
               - if listing.author.has_profile_picture?
                 %td{:valign => "top", :width => "50"}
-                  = link_to((image_tag listing.author.image.url(:thumb), :width => 50, :height => 50, :style => "display:block;margin-right:20px;margin-bottom:10px;margin-top:0;border:0"), person_url(listing.author, @url_params))
+                  = link_to((image_tag(email_image_url(listing.author.image.url(:thumb)), :width => 50, :height => 50, :style => "display:block;margin-right:20px;margin-bottom:10px;margin-top:0;border:0")), person_url(listing.author, @url_params))
               %td{:valign => "top", :style => "margin-bottom: 0;padding-bottom: 0;"}
                 %p{:style => "font-family:Helvetica Neue, Helvetica, Arial, sans-serif;font-weight: normal; font-size: 14px; margin-top: 0;margin-bottom:0;padding:0;line-height:14px;"}
                   - name_link = link_to(PersonViewUtils.person_display_name_for_type(listing.author, "first_name_only"), person_url(listing.author, @url_params), :style => "font-weight:bold;")
@@ -21,7 +21,7 @@
                       = shape_name(listing) + ":"
                     = listing.title
         - unless listing.listing_images.empty?
-          = link_to(image_tag(listing.listing_images.first.image.url(:email), :class => "listing_main_image", :alt => listing.title, :height => "100", :width => "150", :style => "display:block;margin-left:30px;margin-bottom:20px;margin-top:4px;border:0", :align => "right"), listing_url(@url_params.merge({:id => listing.id})))
+          = link_to(image_tag(email_image_url(listing.listing_images.first.image.url(:email)), :class => "listing_main_image", :alt => listing.title, :height => "100", :width => "150", :style => "display:block;margin-left:30px;margin-bottom:20px;margin-top:4px;border:0", :align => "right"), listing_url(@url_params.merge({:id => listing.id})))
         - unless listing.description.blank?
           %p{:style => "font-family:Helvetica Neue, Helvetica, Arial, sans-serif;font-size:16px;font-weight:100px; color:#898989;font-style: italic;line-height:22px;margin-top:0;margin-bottom:8px;"}
             = truncate_html(markdown(listing.description), :length => 200, :omission => "...")

--- a/app/views/community_mailer/community_updates.html.haml
+++ b/app/views/community_mailer/community_updates.html.haml
@@ -12,7 +12,7 @@
                       %tr
                         %td{:width => "5%"}
                         %td{:valign => "top", :width => "90%", :align => "center", :style => "padding-top:5px;"}
-                          = image_tag @community.wide_logo.url(:header), alt: @community.full_name(I18n.locale), style: 'margin: 0 auto;'
+                          = image_tag(email_image_url(@community.wide_logo.url(:header)), alt: @community.full_name(I18n.locale), style: 'margin: 0 auto;')
                         %td{:width => "5%"}
                     %tr
                       %td{:width => "5%"}

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -16,7 +16,7 @@
                 - if community && community.wide_logo.present?
                   %tr
                     %td{align: "center"}
-                      = image_tag community.wide_logo.url(:header), alt: community.full_name(I18n.locale), style: 'margin: 0 auto;'
+                      = image_tag(email_image_url(community.wide_logo.url(:header)), alt: community.full_name(I18n.locale), style: 'margin: 0 auto;')
                 - if @community
                   %tr
                     %td{:align => "left", :style => "padding-top: 20px; padding-bottom: 5px; border-bottom:1px dotted grey;"}

--- a/app/views/person_mailer/welcome_email.html.haml
+++ b/app/views/person_mailer/welcome_email.html.haml
@@ -12,7 +12,7 @@
                       %tr
                         %td{:width => "5%"}
                         %td{:valign => "top", :width => "90%", :align => "center", :style => "padding-top:5px;"}
-                          = image_tag @current_community.wide_logo.url(:header), alt: @current_community.full_name(I18n.locale), style: 'margin: 0 auto;'
+                          = image_tag(email_image_url(@current_community.wide_logo.url(:header)), alt: @current_community.full_name(I18n.locale), style: 'margin: 0 auto;')
                         %td{:width => "5%"}
                     %tr
                       %td{:width => "7.5%"}

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -86,7 +86,7 @@ default: &default_settings
   # - 0c84dc78c9435aec606bbf2428c2c476.cloudfront.com
   # - assets%0.your_domain.com
   #
-  asset_host:
+  asset_host: "https://gigfunding.org"
 
   # Your user-uploaded assets CDN distribution host name, including the desired protocol (http or https).
   #
@@ -508,6 +508,10 @@ staging:
 
 development:
   <<: *default_settings
+
+  # Use localhost for dev
+  domain: 'lvh.me:5000'
+  asset_host: 'http://lvh.me:5000'
 
   # Usually it's easier to run development without SSL
   always_use_ssl: false


### PR DESCRIPTION
**Wrike task:** https://www.wrike.com/open.htm?id=474971716
**Issues:** Email images require absolute path to resolve correctly in most email MUAs
**Changes:** 

- Add asset_path for site into config 
- Create EmailHelper::email_image_url method to add asset_host to email image urls
- Add helper method into email templates to provide absolute url