### PR TITLE
545386648 one thread per transaction

### DIFF
--- a/app/assets/stylesheets/partials/_fluid-grid-listing-image.scss
+++ b/app/assets/stylesheets/partials/_fluid-grid-listing-image.scss
@@ -38,14 +38,13 @@
 }
 
 .fluid-thumbnail-grid-image-image {
-  @include border-top-radius($default-border-radius);
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: 3px;
 }
 
 .fluid-thumbnail-grid-image-price-container {
@@ -53,7 +52,7 @@
   font-size: 12px; // Quantity placeholder font-size, so that the ellipsis looks nice
   max-width: 50%;
   @include ellipsis;
-  border-bottom-right-radius: $default-border-radius;
+  border-bottom-right-radius: 3px;
 }
 
 .fluid-thumbnail-grid-image-price {


### PR DESCRIPTION
**Wrike task:** https://www.wrike.com/open.htm?id=545386648
**Issue:** Duplication of started transactions in the users inbox
**Changes:** Add method in preauthorize transactions controller to remove original 'free' transaction when replaced by successful preauthorize transaction. Also minor CSS adjustment on homepage.
**Deploy:**
- recompile assets
- restart application server