### PR TITLE
Transaction_type=requesting by default in homepage_controller

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -47,7 +47,7 @@ class HomepageController < ApplicationController
       end
     end
 
-    listing_shape_param = params[:transaction_type]
+    listing_shape_param = params[:transaction_type] == "offering" ? params[:transaction_type] : "requesting"
 
     selected_shape = all_shapes.find { |s| s[:name] == listing_shape_param }
 

--- a/app/views/homepage/_grid_item.haml
+++ b/app/views/homepage/_grid_item.haml
@@ -12,7 +12,7 @@
         - if(!show_distance || distance.blank?)
           - listing_title_color = (listing.listing_title_color ? listing.listing_title_color : '')
           = link_to(person_path(username: listing.author.username), :class => "home-fluid-thumbnail-grid-author-name", title: name, style: "color: #{listing_title_color};" ) do
-            = name
+            = name.split(' ').first
             is
             = shape_name(listing)
         - else


### PR DESCRIPTION
Ticket #554856867 - Never show Offers + Requests at same time:

Updated homepage_controller so that homepage shows Requested skills only by default & relevant button is pressed/highlighted. 