### PR TITLE
544877709 default listing title color

### DIFF
--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -16,7 +16,7 @@
 #  updated_at             :datetime         not null
 #  deleted                :boolean          default(FALSE)
 #  listing_color          :string(255)      default("FFFFFF")
-#  listing_title_color    :string(255)
+#  listing_title_color    :string(255)      default("000000")
 #
 # Indexes
 #

--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -50,6 +50,7 @@ class ListingShape < ApplicationRecord
   validate :assign_default_listing_color
   validates :listing_title_color, 
             format: { :with => /\A[A-F0-9]{6}\z/i, :allow_blank => true }
+  validate :assign_default_listing_title_color
 
   def units
     @units ||= listing_units.map(&:to_unit_hash)
@@ -128,6 +129,13 @@ class ListingShape < ApplicationRecord
   def assign_default_listing_color
     if listing_color.blank?
       self.listing_color = 'FFFFFF'
+      self.save
+    end
+  end
+
+  def assign_default_listing_title_color
+    if listing_title_color.blank?
+      self.listing_title_color = '000000'
       self.save
     end
   end

--- a/db/migrate/20200829125313_add_default_listing_title_color_to_listing_shape.rb
+++ b/db/migrate/20200829125313_add_default_listing_title_color_to_listing_shape.rb
@@ -1,0 +1,9 @@
+class AddDefaultListingTitleColorToListingShape < ActiveRecord::Migration[5.2]
+  def up
+    change_column :listing_shapes, :listing_title_color, :string, default: "000000"
+  end
+
+  def down
+    change_column :listing_shapes, :listing_title_color, :string, default: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -793,7 +793,7 @@ CREATE TABLE `listing_shapes` (
   `updated_at` datetime NOT NULL,
   `deleted` tinyint(1) DEFAULT '0',
   `listing_color` varchar(255) DEFAULT 'FFFFFF',
-  `listing_title_color` varchar(255) DEFAULT NULL,
+  `listing_title_color` varchar(255) DEFAULT '000000',
   PRIMARY KEY (`id`),
   KEY `multicol_index` (`community_id`,`deleted`,`sort_priority`) USING BTREE,
   KEY `index_listing_shapes_on_community_id` (`community_id`) USING BTREE,
@@ -2477,8 +2477,10 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200312112018'),
 ('20200617124857'),
 ('20200617170525'),
+('20200617180909'),
 ('20200617181714'),
 ('20200724231501'),
-('20200725114710');
+('20200725114710'),
+('20200829125313');
 
 

--- a/spec/models/listing_shape_spec.rb
+++ b/spec/models/listing_shape_spec.rb
@@ -16,7 +16,7 @@
 #  updated_at             :datetime         not null
 #  deleted                :boolean          default(FALSE)
 #  listing_color          :string(255)      default("FFFFFF")
-#  listing_title_color    :string(255)
+#  listing_title_color    :string(255)      default("000000")
 #
 # Indexes
 #


### PR DESCRIPTION
**Task:** https://www.wrike.com/open.htm?id=544877709
**Issue:** No default color on listing_shape.listing_title_color, leads to white on white in default hover
**Changes:** 
- Add validation hook to listing_shape to add default #000000 on blank update of listing_title_color
- Add migration to update listing_title_color column in listing_shapes to have default value on creation

**Deploy:**
- run db:migrate
- restart application server