### PR TITLE
557525540_add_listing_shape_name_to_list_view

### DIFF
--- a/app/helpers/listings_helper.rb
+++ b/app/helpers/listings_helper.rb
@@ -131,4 +131,8 @@ module ListingsHelper
       I18n.t("admin.communities.listings.status.all")
     end
   end
+
+  def prepend_listing_shape_name(listing)
+    "#{shape_name(listing)}: #{listing.title.sub(/$#{Regexp.quote(shape_name(listing))} */i, '').capitalize}"
+  end
 end

--- a/app/views/homepage/_list_item.haml
+++ b/app/views/homepage/_list_item.haml
@@ -27,7 +27,7 @@
     %div{:class => (listing.listing_images.size > 0 ? "home-list-details-with-image" : "")}
       %h2.home-list-title
         = link_to listing_path(listing.url) do
-          = listing.title
+          = prepend_listing_shape_name(listing)
           - if @current_community.show_category_in_listing_list
             %a.home-share-type-link{:href => search_path(:transaction_type => shape_name_map[listing.listing_shape_id], :view => :list)}
               = icon_tag(listing.icon_name, ["icon-fix"])


### PR DESCRIPTION
**Task:** https://www.wrike.com/open.htm?id=557525540
**Issue:** No listing title in list view on homepage
**Changes:**
- Add helper method to prepend listing shape name to list view title

**Deploy:**
- restart application server