### PR TITLE
562267012 image upload fix

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1680,6 +1680,10 @@ input[type="text"].delivery-price-field {
   @include media(tablet) {
     min-height: 250px;
   }
+
+  img {
+    object-fit: contain;
+  }
 }
 
 /*

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -47,7 +47,7 @@ class HomepageController < ApplicationController
       end
     end
 
-    listing_shape_param = params[:transaction_type] == "offering" ? params[:transaction_type] : "requesting"
+    listing_shape_param = (params[:transaction_type] ? params[:transaction_type] : "requesting")
 
     selected_shape = all_shapes.find { |s| s[:name] == listing_shape_param }
 


### PR DESCRIPTION
**Task:** https://www.wrike.com/open.htm?id=562267012
**Issue:** Images streching in mobile view of about-sections
**Changes:**
- Add CSS to change image to contain instead of default fit
- minor fix to homepage listing shape sorting code

**Deploy:**
- recompile static assets
- restart application server
 