### PR TITLE
512262652 causes edge cases

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -603,7 +603,7 @@ Lint/Void:
 
 # Offense count: 314
 Metrics/AbcSize:
-  Max: 103
+  Max: 104
 
 # Offense count: 268
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -613,7 +613,7 @@ Metrics/BlockLength:
 # Offense count: 39
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 446
+  Max: 600
 
 # Offense count: 56
 Metrics/CyclomaticComplexity:

--- a/app/assets/javascripts/kassi.js
+++ b/app/assets/javascripts/kassi.js
@@ -920,6 +920,12 @@ function initialize_admin_causes_form_validations(form_id, ignore_file_field = f
 
 function initialize_admin_causes_delete_warning(form_id, cause_name) {
   $(form_id).on('submit', function() {
-    return confirm('Do you really want to delete ' + cause_name + '?');
+    return confirm('Do you really want to delete ' + cause_name + '? This can not be undone');
+  });
+}
+
+function initialize_admin_causes_archive_warning(form_id, cause_name) {
+  $(form_id).on('submit', function() {
+    return confirm('Do you really want to archive ' + cause_name + '? This will reset all users who have selected it to the default cause, which can not be undone.');
   });
 }

--- a/app/assets/stylesheets/views/_causes.scss
+++ b/app/assets/stylesheets/views/_causes.scss
@@ -59,7 +59,7 @@ $hover-transition: 0.1s;
   justify-content: center;
   @include border-radius(em(5));
   padding: lines(0.3) lines(0.3);
-  width: 100%;
+  width: 100px;
   align-items: center;
   line-height: inherit;
 

--- a/app/assets/stylesheets/views/_causes.scss
+++ b/app/assets/stylesheets/views/_causes.scss
@@ -51,7 +51,6 @@ $hover-transition: 0.1s;
 
 .cause-action-button {
   position: relative;
-  height: 50px;
   margin: 5px 0px;
   background: $highlight;
   color: $body;
@@ -59,7 +58,10 @@ $hover-transition: 0.1s;
   flex-direction: column;
   justify-content: center;
   @include border-radius(em(5));
-  padding: 0 lines(0.3);
+  padding: lines(0.3) lines(0.3);
+  width: 100%;
+  align-items: center;
+  line-height: inherit;
 
   &:hover, &:active {
     background: darken($highlight, 30%);
@@ -78,6 +80,17 @@ $hover-transition: 0.1s;
 
   &:hover, &:active {
     background: darken($error-red, 20%);
+    color: $background;
+  }
+}
+
+.cause-action-archive {
+  background: #3ab7fa;
+  color: $background;
+  border: none;
+
+  &:hover, &:active {
+    background: darken(#3ab7fa, 30%);
     color: $background;
   }
 }

--- a/app/assets/stylesheets/views/_causes.scss
+++ b/app/assets/stylesheets/views/_causes.scss
@@ -79,7 +79,7 @@ $hover-transition: 0.1s;
   border: none;
 
   &:hover, &:active {
-    background: darken($error-red, 20%);
+    background: darken($error-red, 15%);
     color: $background;
   }
 }
@@ -90,7 +90,7 @@ $hover-transition: 0.1s;
   border: none;
 
   &:hover, &:active {
-    background: darken(#3ab7fa, 30%);
+    background: darken(#3ab7fa, 15%);
     color: $background;
   }
 }
@@ -101,7 +101,7 @@ $hover-transition: 0.1s;
   border: none;
 
   &:hover, &:active {
-    background: darken(#27a727, 30%);
+    background: darken(#27a727, 15%);
     color: $background;
   }
 }

--- a/app/assets/stylesheets/views/_causes.scss
+++ b/app/assets/stylesheets/views/_causes.scss
@@ -95,6 +95,17 @@ $hover-transition: 0.1s;
   }
 }
 
+.cause-action-unarchive {
+  background: #27a727;
+  color: $background;
+  border: none;
+
+  &:hover, &:active {
+    background: darken(#27a727, 30%);
+    color: $background;
+  }
+}
+
 .cause-name {
   @include big-type;
   margin-bottom: 5px;

--- a/app/controllers/admin/causes_controller.rb
+++ b/app/controllers/admin/causes_controller.rb
@@ -2,7 +2,9 @@ class Admin::CausesController < Admin::AdminBaseController
   before_action :set_selected_left_navi_link
 
   def index
-    @causes = Cause.where(community: @current_community)
+    @causes = Cause.where(community: @current_community, archived: false, default_cause: false)
+    @default_cause = Cause.find_by(default_cause: true)
+    @archived_causes = Cause.where(community: @current_community, archived: true, default_cause: false)
   end
 
   def new

--- a/app/controllers/admin/causes_controller.rb
+++ b/app/controllers/admin/causes_controller.rb
@@ -52,6 +52,6 @@ class Admin::CausesController < Admin::AdminBaseController
   end
 
   def cause_params
-    params.require(:cause).permit(:name, :description, :link, :logo)
+    params.require(:cause).permit(:name, :description, :link, :logo, :archived)
   end
 end

--- a/app/controllers/admin/causes_controller.rb
+++ b/app/controllers/admin/causes_controller.rb
@@ -3,7 +3,7 @@ class Admin::CausesController < Admin::AdminBaseController
 
   def index
     @causes = Cause.where(community: @current_community, archived: false, default_cause: false)
-    @default_cause = Cause.find_by(default_cause: true)
+    @default_cause = Cause.find_by(community: @current_community, default_cause: true)
     @archived_causes = Cause.where(community: @current_community, archived: true, default_cause: false)
   end
 

--- a/app/controllers/admin/causes_controller.rb
+++ b/app/controllers/admin/causes_controller.rb
@@ -2,9 +2,9 @@ class Admin::CausesController < Admin::AdminBaseController
   before_action :set_selected_left_navi_link
 
   def index
-    @causes = Cause.where(community: @current_community, archived: false, default_cause: false)
-    @default_cause = Cause.find_by(community: @current_community, default_cause: true)
-    @archived_causes = Cause.where(community: @current_community, archived: true, default_cause: false)
+    @causes = Cause.available.where(community: @current_community, archived: false, default_cause: false)
+    @default_cause = Cause.available.find_by(community: @current_community, default_cause: true)
+    @archived_causes = Cause.available.where(community: @current_community, archived: true, default_cause: false)
   end
 
   def new
@@ -24,11 +24,11 @@ class Admin::CausesController < Admin::AdminBaseController
   end
 
   def edit
-    @cause = Cause.find(params[:id])
+    @cause = Cause.available.find(params[:id])
   end
 
   def update
-    @cause = Cause.find(params[:id])
+    @cause = Cause.available.find(params[:id])
     if @cause.update(cause_params)
       redirect_to admin_causes_path, notice:  "Cause updated"
     else
@@ -38,8 +38,8 @@ class Admin::CausesController < Admin::AdminBaseController
   end
 
   def destroy
-    @cause = Cause.find(params[:id])
-    if @cause.destroy()
+    @cause = Cause.available.find(params[:id])
+    if @cause.update(deleted: true)
       redirect_to admin_causes_path, notice: 'Cause deleted'
     else
       flash[:error] = @cause.errors.map {|k, v| (k.to_s + ' ' + v.to_s).humanize}.join(', ')

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -47,7 +47,7 @@ class HomepageController < ApplicationController
       end
     end
 
-    listing_shape_param = (params[:transaction_type] ? params[:transaction_type] : "requesting")
+    listing_shape_param = (params[:transaction_type] || "requesting")
 
     selected_shape = all_shapes.find { |s| s[:name] == listing_shape_param }
 

--- a/app/jobs/cause_reset_job.rb
+++ b/app/jobs/cause_reset_job.rb
@@ -1,0 +1,19 @@
+class CauseResetJob < Struct.new(:person_id, :cause_id, :community_id)
+
+  include DelayedAirbrakeNotification
+
+  # This before hook should be included in all Jobs to make sure that the service_name is
+  # correct as it's stored in the thread and the same thread handles many different communities
+  # if the job doesn't have host parameter, should call the method with nil, to set the default service_name
+  def before(job)
+    # Set the correct service name to thread for I18n to pick it
+    ApplicationHelper.store_community_service_name_to_thread_from_community_id(community_id)
+  end
+
+  def perform
+    person = Person.find(person_id)
+    cause = Cause.find(cause_id)
+
+    MailCarrier.deliver_now(PersonMailer.cause_reset(person, cause))
+  end
+end

--- a/app/jobs/cause_reset_job.rb
+++ b/app/jobs/cause_reset_job.rb
@@ -13,7 +13,8 @@ class CauseResetJob < Struct.new(:person_id, :cause_id, :community_id)
   def perform
     person = Person.find(person_id)
     cause = Cause.find(cause_id)
+    community = Community.find(community_id)
 
-    MailCarrier.deliver_now(PersonMailer.cause_reset(person, cause))
+    MailCarrier.deliver_now(PersonMailer.cause_reset(person, cause, community))
   end
 end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -480,7 +480,6 @@ class PersonMailer < ActionMailer::Base
   end
 
   def cause_reset(recipient, cause, community)
-    @email_type =  "email_about_cause_being_reset"
     @cause_name = cause.name
     @community_name = community.name(I18n.locale)
     @skip_unsubscribe_footer = true

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -479,6 +479,12 @@ class PersonMailer < ActionMailer::Base
     premailer(mail(opts, &block))
   end
 
+  def cause_reset(person, cause)
+    @person = person
+    @cause = cause
+    # add email to notify user to select a new cause, include link to user settings
+  end
+
   private
 
   def feedback_author_name_and_email(author, email, community)

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -272,7 +272,7 @@ class PersonMailer < ActionMailer::Base
 
   # Used to send notification to marketplace admins when somebody
   # gives feedback on marketplace throught the contact us button in menu
-  def new_feedback(feedback, community)e
+  def new_feedback(feedback, community)
     subject = t("feedback.feedback_subject", service_name: community.name(I18n.locale))
 
     premailer_mail(
@@ -483,6 +483,7 @@ class PersonMailer < ActionMailer::Base
     @email_type =  "email_about_cause_being_reset"
     @cause_name = cause.name
     @community_name = community.name(I18n.locale)
+    @skip_unsubscribe_footer = true
     set_up_layout_variables(recipient, community, @email_type)
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
       subject = t("emails.cause_reset.subject", :community => community.full_name(recipient.locale))

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -489,7 +489,7 @@ class PersonMailer < ActionMailer::Base
       mail(:to => recipient.confirmed_notification_emails_to,
            :from => community_specific_sender(community),
            :subject => subject) do |format|
-        format.html { render v2_template(community.id, 'cause_reset'), layout: v2_layout(community.id, 'email_blank_layout') }
+        format.html { render v2_template(community.id, 'cause_reset'), layout: v2_layout(community.id) }
       end
     end
   end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -98,7 +98,7 @@ class PersonMailer < ActionMailer::Base
   end
 
   def new_testimonial(testimonial, community)
-    @email_type =  "email_about_new_received_testimonials"
+    @email_type = "email_about_new_received_testimonials"
     recipient = testimonial.receiver
     set_up_layout_variables(recipient, community, @email_type)
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
@@ -272,7 +272,7 @@ class PersonMailer < ActionMailer::Base
 
   # Used to send notification to marketplace admins when somebody
   # gives feedback on marketplace throught the contact us button in menu
-  def new_feedback(feedback, community)
+  def new_feedback(feedback, community)e
     subject = t("feedback.feedback_subject", service_name: community.name(I18n.locale))
 
     premailer_mail(
@@ -479,10 +479,19 @@ class PersonMailer < ActionMailer::Base
     premailer(mail(opts, &block))
   end
 
-  def cause_reset(person, cause)
-    @person = person
-    @cause = cause
-    # add email to notify user to select a new cause, include link to user settings
+  def cause_reset(recipient, cause, community)
+    @email_type =  "email_about_cause_being_reset"
+    @cause_name = cause.name
+    @community_name = community.name(I18n.locale)
+    set_up_layout_variables(recipient, community, @email_type)
+    with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
+      subject = t("emails.cause_reset.subject", :community => community.full_name(recipient.locale))
+      mail(:to => recipient.confirmed_notification_emails_to,
+           :from => community_specific_sender(community),
+           :subject => subject) do |format|
+        format.html { render v2_template(community.id, 'cause_reset'), layout: v2_layout(community.id, 'email_blank_layout') }
+      end
+    end
   end
 
   private

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -58,7 +58,7 @@ class Cause < ApplicationRecord
   before_destroy :reset_person_cause
 
   def reset_person_cause
-    self.people.each{|person| 
+    self.people.each{|person|
       previous_cause_id = person.cause_id
       person.cause_id = nil
       person.save

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -50,4 +50,13 @@ class Cause < ApplicationRecord
   validates_attachment_content_type :logo, content_type: IMAGE_CONTENT_TYPE
 
   process_in_background :logo
+
+  before_destroy :reset_person_cause
+
+  def reset_person_cause
+    self.people.each{|person| 
+      person.cause_id = nil
+      person.save
+    }
+  end
 end

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -52,6 +52,7 @@ class Cause < ApplicationRecord
 
   process_in_background :logo
 
+  after_save :apply_archived
   before_destroy :reset_person_cause
 
   def reset_person_cause
@@ -59,5 +60,11 @@ class Cause < ApplicationRecord
       person.cause_id = nil
       person.save
     }
+  end
+
+  private
+
+  def apply_archived
+    self.reset_person_cause if self.archived
   end
 end

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -13,6 +13,7 @@
 #  logo_file_size    :integer
 #  logo_updated_at   :datetime
 #  community_id      :bigint
+#  default_cause     :boolean          default(FALSE)
 #
 # Indexes
 #
@@ -20,6 +21,14 @@
 #
 
 class Cause < ApplicationRecord
+
+  DEFAULT = {
+    name: 'Unselected (Gigfunding)',
+    description: 'Your cause is not selected. Until you select a cause, all donations will be paid to Gigfunding.org. Causes can be selected and changed near the bottom of your Settings page.',
+    link: 'https://gigfunding.org',
+    default_cause: true
+  }
+
   belongs_to :community, foreign_key: 'community_id'
   has_many :people, foreign_key: "cause_id"
   has_many :transactions, foreign_key: 'starter_cause_id'

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -15,6 +15,7 @@
 #  community_id      :bigint
 #  default_cause     :boolean          default(FALSE)
 #  archived          :boolean          default(FALSE)
+#  deleted           :boolean          default(FALSE)
 #
 # Indexes
 #
@@ -51,6 +52,8 @@ class Cause < ApplicationRecord
 
   process_in_background :logo
 
+  scope :available, -> {where(:deleted => false)}
+
   after_save :apply_archived
   before_destroy :reset_person_cause
 
@@ -64,6 +67,6 @@ class Cause < ApplicationRecord
   private
 
   def apply_archived
-    self.reset_person_cause if self.archived
+    self.reset_person_cause if self.archived || self.deleted
   end
 end

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -26,7 +26,6 @@ class Cause < ApplicationRecord
   DEFAULT = {
     name: 'Unselected (Gigfunding)',
     description: 'Your cause is not selected. Until you select a cause, all donations will be paid to Gigfunding.org. Causes can be selected and changed near the bottom of your Settings page.',
-    link: 'https://gigfunding.org',
     default_cause: true
   }
 

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -14,6 +14,7 @@
 #  logo_updated_at   :datetime
 #  community_id      :bigint
 #  default_cause     :boolean          default(FALSE)
+#  archived          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -173,7 +173,7 @@ class Community < ApplicationRecord
   accepts_nested_attributes_for :social_links, allow_destroy: true
   accepts_nested_attributes_for :community_customizations
 
-  after_create :initialize_settings
+  after_create :initialize_settings, :add_default_cause
 
   monetize :minimum_price_cents, :allow_nil => true, :with_model_currency => :currency
 
@@ -703,5 +703,11 @@ class Community < ApplicationRecord
   def initialize_settings
     update_attribute(:settings,{"locales"=>[APP_CONFIG.default_locale]}) if self.settings.blank?
     true
+  end
+
+  def add_default_cause
+    cause_params = Cause::DEFAULT
+    cause_params[:community_id] = self.id
+    Cause.create(cause_params)
   end
 end

--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -36,6 +36,7 @@ class ListingShape < ApplicationRecord
   belongs_to :transaction_process
   has_and_belongs_to_many :categories, -> { order("sort_priority") }, join_table: "category_listing_shapes"
   has_many :listing_units, dependent: :destroy
+  has_many :listings
 
   scope :exist, -> { where(deleted: false) }
   scope :exist_ordered, -> { exist.includes(:listing_units).order("listing_shapes.sort_priority") }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -240,6 +240,8 @@ class Person < ApplicationRecord
     set_default_preferences unless self.preferences
   end
 
+  before_save :assign_default_cause
+
   after_initialize :add_uuid
   def add_uuid
     self.uuid ||= UUIDUtils.create_raw
@@ -618,6 +620,12 @@ class Person < ApplicationRecord
 
   def logger_metadata
     { person_uuid: uuid }
+  end
+
+  def assign_default_cause
+    unless self.cause_id
+      self.cause_id = Cause.find_by(default_cause: true).id
+    end
   end
 
   class << self

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -624,7 +624,7 @@ class Person < ApplicationRecord
 
   def assign_default_cause
     unless self.cause_id
-      default_cause = Cause.find_by(default_cause: true)
+      default_cause = Cause.available.find_by(default_cause: true)
       self.cause_id = (default_cause ? default_cause.id : nil )
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -624,7 +624,8 @@ class Person < ApplicationRecord
 
   def assign_default_cause
     unless self.cause_id
-      self.cause_id = Cause.find_by(default_cause: true).id
+      default_cause = Cause.find_by(default_cause: true)
+      self.cause_id = (default_cause ? default_cause.id : nil )
     end
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -625,7 +625,7 @@ class Person < ApplicationRecord
   def assign_default_cause
     unless self.cause_id
       default_cause = Cause.available.find_by(default_cause: true)
-      self.cause_id = (default_cause ? default_cause.id : nil )
+      self.cause_id = (default_cause ? default_cause.id : nil)
     end
   end
 

--- a/app/services/person/settings_service.rb
+++ b/app/services/person/settings_service.rb
@@ -7,7 +7,7 @@ class Person::SettingsService
     @required_fields_only = required_fields_only
     @person = person
     @current_user = current_user
-    @causes = get_causes
+    @causes = available_causes
   end
 
   delegate :person_custom_fields, to: :community, prefix: true
@@ -76,7 +76,7 @@ class Person::SettingsService
     scope
   end
 
-  def get_causes
+  def available_causes
     Cause.available.where(community: @community, default_cause: false, archived: false)
   end
 end

--- a/app/services/person/settings_service.rb
+++ b/app/services/person/settings_service.rb
@@ -77,6 +77,6 @@ class Person::SettingsService
   end
 
   def get_causes
-    Cause.where(community: @community)
+    Cause.where(community: @community, default_cause: false, archived: false)
   end
 end

--- a/app/services/person/settings_service.rb
+++ b/app/services/person/settings_service.rb
@@ -77,6 +77,6 @@ class Person::SettingsService
   end
 
   def get_causes
-    Cause.where(community: @community, default_cause: false, archived: false)
+    Cause.available.where(community: @community, default_cause: false, archived: false)
   end
 end

--- a/app/services/stripe_service/report.rb
+++ b/app/services/stripe_service/report.rb
@@ -224,7 +224,7 @@ class StripeService::Report
   def create_charge
     {
       "stripe_op": "create_charge",
-      "transaction_id": tx.id,
+      "transaction_id": tx.id
     }
   end
 

--- a/app/services/stripe_service/report.rb
+++ b/app/services/stripe_service/report.rb
@@ -217,7 +217,6 @@ class StripeService::Report
       "stripe_op": "capture_charge",
       "transaction_id": tx.id,
       "stripe_payment_id": stripe_payment.id,
-      "stripe_seller_id": stripe_account.stripe_seller_id,
       "stripe_charge_id": stripe_payment.stripe_charge_id
     }
   end
@@ -226,7 +225,6 @@ class StripeService::Report
     {
       "stripe_op": "create_charge",
       "transaction_id": tx.id,
-      "stripe_seller_id": stripe_account.stripe_seller_id
     }
   end
 
@@ -234,7 +232,6 @@ class StripeService::Report
     {
       "stripe_op": "cancel_charge",
       "transaction_id": tx.id,
-      "stripe_seller_id": stripe_account.stripe_seller_id,
       "stripe_payment_id": stripe_payment.id,
       "stripe_charge_id": stripe_payment.stripe_charge_id
     }
@@ -245,7 +242,6 @@ class StripeService::Report
       "stripe_op": "create_payout",
       "transaction_id": tx.id,
       "stripe_payment_id": stripe_payment.id,
-      "stripe_seller_id": stripe_account.stripe_seller_id,
       "stripe_charge_id": stripe_payment.stripe_charge_id
     }
   end
@@ -253,8 +249,7 @@ class StripeService::Report
   def create_intent
     {
       "stripe_op": "create_intent",
-      "transaction_id": tx.id,
-      "stripe_seller_id": stripe_account.stripe_seller_id
+      "transaction_id": tx.id
     }
   end
 
@@ -263,7 +258,6 @@ class StripeService::Report
       "stripe_op": "cancel_intent",
       "transaction_id": tx.id,
       "stripe_payment_id": stripe_payment.id,
-      "stripe_seller_id": stripe_account.stripe_seller_id,
       "stripe_charge_id": stripe_payment.stripe_charge_id,
       "stripe_payment_intent_id": stripe_payment.stripe_payment_intent_id
     }
@@ -274,7 +268,6 @@ class StripeService::Report
       "stripe_op": "capture_intent",
       "transaction_id": tx.id,
       "stripe_payment_id": stripe_payment.id,
-      "stripe_seller_id": stripe_account.stripe_seller_id,
       "stripe_charge_id": stripe_payment.stripe_charge_id,
       "stripe_payment_intent_id": stripe_payment.stripe_payment_intent_id
     }

--- a/app/view_utils/listing_index_view_utils.rb
+++ b/app/view_utils/listing_index_view_utils.rb
@@ -41,9 +41,9 @@ module ListingIndexViewUtils
 
   def to_struct(result:, includes:, per_page:, page:)
     custom_listing_colors = ListingShape.where(deleted: 0).each_with_object({}) {|listing_shape, obj|
-    obj[listing_shape.id] = {
-      listing_color: '#' + listing_shape.listing_color.to_s,
-      listing_title_color: '#' + listing_shape.listing_title_color.to_s
+      obj[listing_shape.id] = {
+        listing_color: '#' + listing_shape.listing_color.to_s,
+        listing_title_color: '#' + listing_shape.listing_title_color.to_s
       }
     }
 
@@ -72,6 +72,8 @@ module ListingIndexViewUtils
         else
           []
         end
+
+      # byebug
 
       listing_colors = custom_listing_colors[l[:listing_shape_id]]
 

--- a/app/views/admin/causes/edit.haml
+++ b/app/views/admin/causes/edit.haml
@@ -16,7 +16,7 @@
       = t('.current_cause_details')
   .row
     .col-12
-      = render :partial => "layouts/cause_layout", :locals => {cause: @cause, edit_cause: false, delete_cause: false}
+      = render :partial => "layouts/cause_layout", :locals => {cause: @cause, admin: false}
 
   .top-level-category-divider-wrapper
     .top-level-category-divider

--- a/app/views/admin/causes/edit.haml
+++ b/app/views/admin/causes/edit.haml
@@ -24,7 +24,8 @@
   = form_for [:admin, @cause] do |form|
     = render :partial => "admin/causes/form/name", :locals => { :form => form }
     = render :partial => "admin/causes/form/description", :locals => { :form => form }
-    = render :partial => "admin/causes/form/link", :locals => { :form => form }
+    - unless @cause.default_cause
+      = render :partial => "admin/causes/form/link", :locals => { :form => form }
     = render :partial => "admin/causes/form/logo", :locals => { :form => form }
     = render :partial => "admin/causes/form/buttons", :locals => { :form => form }
 

--- a/app/views/admin/causes/edit.haml
+++ b/app/views/admin/causes/edit.haml
@@ -16,7 +16,7 @@
       = t('.current_cause_details')
   .row
     .col-12
-      = render :partial => "layouts/cause_layout", :locals => {cause: @cause, admin: false}
+      = render :partial => "layouts/cause_layout", :locals => {cause: @cause, admin: false, is_current_user_viewing: @cause.default_cause}
 
   .top-level-category-divider-wrapper
     .top-level-category-divider

--- a/app/views/admin/causes/index.haml
+++ b/app/views/admin/causes/index.haml
@@ -35,3 +35,15 @@
     = render :partial => "layouts/info_text", :locals => { :text => t(".default_causes_help")} 
 
   = render :partial => "layouts/cause_layout", :locals => {cause: @default_cause, admin: true, is_current_user_viewing: true}
+
+
+  %br
+  .row
+    .col-12
+    %h3
+      = t(".archived_causes")
+
+    = render :partial => "layouts/info_text", :locals => { :text => t(".archived_causes_help")} 
+  
+  - @archived_causes.each do |cause|
+    = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: true, is_current_user_viewing: true}

--- a/app/views/admin/causes/index.haml
+++ b/app/views/admin/causes/index.haml
@@ -25,3 +25,13 @@
   .row
     .col-12
       = link_to t(".create_a_new_cause"), new_admin_cause_path
+  
+  %br
+  .row
+    .col-12
+    %h3
+      = t(".default_causes")
+
+    = render :partial => "layouts/info_text", :locals => { :text => t(".default_causes_help")} 
+
+  = render :partial => "layouts/cause_layout", :locals => {cause: @default_cause, admin: true}

--- a/app/views/admin/causes/index.haml
+++ b/app/views/admin/causes/index.haml
@@ -17,7 +17,7 @@
     = render :partial => "layouts/info_text", :locals => { :text => t(".causes_help")} 
 
   - @causes.each do |cause|
-    = render :partial => "layouts/cause_layout", :locals => {cause: cause, edit_cause: true, delete_cause: true}
+    = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: true}
   
   .top-level-category-divider-wrapper
     .top-level-category-divider

--- a/app/views/admin/causes/index.haml
+++ b/app/views/admin/causes/index.haml
@@ -17,7 +17,7 @@
     = render :partial => "layouts/info_text", :locals => { :text => t(".causes_help")} 
 
   - @causes.each do |cause|
-    = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: true}
+    = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: true, is_current_user_viewing: true}
   
   .top-level-category-divider-wrapper
     .top-level-category-divider
@@ -34,4 +34,4 @@
 
     = render :partial => "layouts/info_text", :locals => { :text => t(".default_causes_help")} 
 
-  = render :partial => "layouts/cause_layout", :locals => {cause: @default_cause, admin: true}
+  = render :partial => "layouts/cause_layout", :locals => {cause: @default_cause, admin: true, is_current_user_viewing: true}

--- a/app/views/layouts/_cause_layout.haml
+++ b/app/views/layouts/_cause_layout.haml
@@ -27,24 +27,27 @@
           = t('.edit_cause')
 
       - unless cause.default_cause
-        - archive_cause_form_id = 'archive_cause_' + cause.id.to_s
-        = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: archive_cause_form_id } do |f|
-          = f.hidden_field :archived, value: true
-          = f.submit t('.archive_cause'), class: 'cause-action-button cause-action-archive'
+        - if cause.archived
+          - unarchive_cause_form_id = 'unarchive_cause_' + cause.id.to_s
+          = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: unarchive_cause_form_id } do |f|
+            = f.hidden_field :archived, value: false
+            = f.submit t('.unarchive_cause'), class: 'cause-action-button cause-action-unarchive'
+          
+          - delete_cause_form_id = 'delete_cause_' + cause.id.to_s
+          = form_for cause, :method => :delete, url: admin_cause_path(cause), html: { id: delete_cause_form_id } do |f|
+            = f.submit t('.delete_cause'), class: 'cause-action-button cause-action-delete'
 
-          - content_for :javascript do
-            initialize_admin_causes_archive_warning('##{j(archive_cause_form_id)}', '#{j(cause.name)}');
+            - content_for :javascript do
+              initialize_admin_causes_delete_warning('##{j(delete_cause_form_id)}', '#{j(cause.name)}');
+        - else
+          - archive_cause_form_id = 'archive_cause_' + cause.id.to_s
+          = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: archive_cause_form_id } do |f|
+            = f.hidden_field :archived, value: true
+            = f.submit t('.archive_cause'), class: 'cause-action-button cause-action-archive'
 
-        - unarchive_cause_form_id = 'unarchive_cause_' + cause.id.to_s
-        = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: unarchive_cause_form_id } do |f|
-          = f.hidden_field :archived, value: false
-          = f.submit t('.unarchive_cause'), class: 'cause-action-button cause-action-unarchive'
+            - content_for :javascript do
+              initialize_admin_causes_archive_warning('##{j(archive_cause_form_id)}', '#{j(cause.name)}');
+
         
-        - delete_cause_form_id = 'delete_cause_' + cause.id.to_s
-        = form_for cause, :method => :delete, url: admin_cause_path(cause), html: { id: delete_cause_form_id } do |f|
-          = f.submit t('.delete_cause'), class: 'cause-action-button cause-action-delete'
-
-          - content_for :javascript do
-            initialize_admin_causes_delete_warning('##{j(delete_cause_form_id)}', '#{j(cause.name)}');
 
 

--- a/app/views/layouts/_cause_layout.haml
+++ b/app/views/layouts/_cause_layout.haml
@@ -8,15 +8,25 @@
       = cause.description
     .cause-link
       = link_to t('.link', cause_name: cause.name), cause.link, target: :_blank
-  - if edit_cause || delete_cause
+  - if admin
     .cause-action-container 
-      - if edit_cause
-        %a{href: edit_admin_cause_path(cause), class: 'cause-action-button'}        
-          %span
-            = t('.edit_cause')
-      - if delete_cause
-        = form_for cause, :method => :delete, url: admin_cause_path(cause) do |f|
-          = f.submit t('.delete_cause'), class: 'cause-action-button cause-action-delete'
+      %a{href: edit_admin_cause_path(cause), class: 'cause-action-button'}        
+        %span
+          = t('.edit_cause')
 
-          - content_for :javascript do
-            initialize_admin_causes_delete_warning('##{j(f.options[:html][:id])}', '##{j(cause.name)}');
+      - archive_cause_form_id = 'archive_cause_' + cause.id.to_s
+      = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: archive_cause_form_id } do |f|
+        = f.hidden_field :archived, value: true
+        = f.submit t('.archive_cause'), class: 'cause-action-button cause-action-archive'
+
+        - content_for :javascript do
+          initialize_admin_causes_archive_warning('##{j(archive_cause_form_id)}', '#{j(cause.name)}');
+      
+      - delete_cause_form_id = 'delete_cause_' + cause.id.to_s
+      = form_for cause, :method => :delete, url: admin_cause_path(cause), html: { id: delete_cause_form_id } do |f|
+        = f.submit t('.delete_cause'), class: 'cause-action-button cause-action-delete'
+
+        - content_for :javascript do
+          initialize_admin_causes_delete_warning('##{j(delete_cause_form_id)}', '#{j(cause.name)}');
+
+

--- a/app/views/layouts/_cause_layout.haml
+++ b/app/views/layouts/_cause_layout.haml
@@ -21,6 +21,11 @@
 
         - content_for :javascript do
           initialize_admin_causes_archive_warning('##{j(archive_cause_form_id)}', '#{j(cause.name)}');
+
+      - unarchive_cause_form_id = 'unarchive_cause_' + cause.id.to_s
+      = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: unarchive_cause_form_id } do |f|
+        = f.hidden_field :archived, value: false
+        = f.submit t('.unarchive_cause'), class: 'cause-action-button cause-action-unarchive'
       
       - delete_cause_form_id = 'delete_cause_' + cause.id.to_s
       = form_for cause, :method => :delete, url: admin_cause_path(cause), html: { id: delete_cause_form_id } do |f|

--- a/app/views/layouts/_cause_layout.haml
+++ b/app/views/layouts/_cause_layout.haml
@@ -6,8 +6,13 @@
       = cause.name
     .cause-description
       = cause.description
+
     .cause-link
-      = link_to t('.link', cause_name: cause.name), cause.link, target: :_blank
+      - if cause.default_cause
+        = link_to t('.edit_person_settings'), person_settings_path(@current_user)
+      - else
+        = link_to t('.link', cause_name: cause.name), cause.link, target: :_blank
+
   - if admin
     .cause-action-container 
       %a{href: edit_admin_cause_path(cause), class: 'cause-action-button'}        

--- a/app/views/layouts/_cause_layout.haml
+++ b/app/views/layouts/_cause_layout.haml
@@ -2,15 +2,22 @@
   .cause-logo-container
     = image_tag cause.logo.url(:square)
   .cause-info-container
-    .cause-name
-      = cause.name
-    .cause-description
-      = cause.description
-
-    .cause-link
-      - if cause.default_cause
+    - if cause.default_cause && is_current_user_viewing
+      .cause-name
+        = cause.name
+      .cause-description
+        = cause.description
+      .cause-link
         = link_to t('.edit_person_settings'), person_settings_path(@current_user)
-      - else
+    - elsif cause.default_cause
+      .cause-name
+        = t('.default_cause_public')
+    - else
+      .cause-name
+        = cause.name
+      .cause-description
+        = cause.description
+      .cause-link
         = link_to t('.link', cause_name: cause.name), cause.link, target: :_blank
 
   - if admin

--- a/app/views/layouts/_cause_layout.haml
+++ b/app/views/layouts/_cause_layout.haml
@@ -14,24 +14,25 @@
         %span
           = t('.edit_cause')
 
-      - archive_cause_form_id = 'archive_cause_' + cause.id.to_s
-      = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: archive_cause_form_id } do |f|
-        = f.hidden_field :archived, value: true
-        = f.submit t('.archive_cause'), class: 'cause-action-button cause-action-archive'
+      - unless cause.default_cause
+        - archive_cause_form_id = 'archive_cause_' + cause.id.to_s
+        = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: archive_cause_form_id } do |f|
+          = f.hidden_field :archived, value: true
+          = f.submit t('.archive_cause'), class: 'cause-action-button cause-action-archive'
 
-        - content_for :javascript do
-          initialize_admin_causes_archive_warning('##{j(archive_cause_form_id)}', '#{j(cause.name)}');
+          - content_for :javascript do
+            initialize_admin_causes_archive_warning('##{j(archive_cause_form_id)}', '#{j(cause.name)}');
 
-      - unarchive_cause_form_id = 'unarchive_cause_' + cause.id.to_s
-      = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: unarchive_cause_form_id } do |f|
-        = f.hidden_field :archived, value: false
-        = f.submit t('.unarchive_cause'), class: 'cause-action-button cause-action-unarchive'
-      
-      - delete_cause_form_id = 'delete_cause_' + cause.id.to_s
-      = form_for cause, :method => :delete, url: admin_cause_path(cause), html: { id: delete_cause_form_id } do |f|
-        = f.submit t('.delete_cause'), class: 'cause-action-button cause-action-delete'
+        - unarchive_cause_form_id = 'unarchive_cause_' + cause.id.to_s
+        = form_for cause, :method => :put, url: admin_cause_path(cause), html: { id: unarchive_cause_form_id } do |f|
+          = f.hidden_field :archived, value: false
+          = f.submit t('.unarchive_cause'), class: 'cause-action-button cause-action-unarchive'
+        
+        - delete_cause_form_id = 'delete_cause_' + cause.id.to_s
+        = form_for cause, :method => :delete, url: admin_cause_path(cause), html: { id: delete_cause_form_id } do |f|
+          = f.submit t('.delete_cause'), class: 'cause-action-button cause-action-delete'
 
-        - content_for :javascript do
-          initialize_admin_causes_delete_warning('##{j(delete_cause_form_id)}', '#{j(cause.name)}');
+          - content_for :javascript do
+            initialize_admin_causes_delete_warning('##{j(delete_cause_form_id)}', '#{j(cause.name)}');
 
 

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -6,8 +6,8 @@
 
   %body
 
-    %table{:cellspacing => "0", :border => "0", :height => "100%", :bgcolor => "#ffffff", :cellpadding => "0", :width => "100%"}
-      %tbody>
+    %table{:cellspacing => "0", :border => "0", :height => "100%", :bgcolor => "#ffffff", :cellpadding => "0", :width => "100%", style: 'font-family:Helvetica Neue, Arial, Helvetica, Arial, sans-serif;'}
+      %tbody
         %tr
           %td{:align => "center", :valign => "top"}
             %table{:cellspacing => "0", :cellpadding => "0", :width => "400"}
@@ -24,9 +24,8 @@
                         = @community.full_name(I18n.locale)
                 - if @recipient && ! @no_recipient_name
                   %tr
-                    %td{:align => "left", :style => "padding-top: 20px; padding-bottom: 10px;"}
-                      %font{body_font}
-                        = t("emails.common.hey", :name => PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"))
+                    %td{:align => "left", :style => "padding-top: 20px; padding-bottom: 10px; font-weight:bold;"}
+                      = t("emails.common.hey", :name => PersonViewUtils.person_display_name_for_type(@recipient, "first_name_only"))
 
 
                 %span{id: SecureRandom.hex}

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -116,7 +116,7 @@
     - if @listing.author.cause
       .label
         = t('settings.profile.selected_cause')
-      = render :partial => "layouts/cause_layout", :locals => {cause: @listing.author.cause, admin: false}
+      = render :partial => "layouts/cause_layout", :locals => {cause: @listing.author.cause, admin: false, is_current_user_viewing: (@listing.author == @current_user)}
 
     - unless (@listing.closed? && !current_user?(@listing.author)) || !@current_community.listing_comments_in_use
       .view-item

--- a/app/views/listings/show.haml
+++ b/app/views/listings/show.haml
@@ -116,7 +116,7 @@
     - if @listing.author.cause
       .label
         = t('settings.profile.selected_cause')
-      = render :partial => "layouts/cause_layout", :locals => {cause: @listing.author.cause, edit_cause: false, delete_cause: false}
+      = render :partial => "layouts/cause_layout", :locals => {cause: @listing.author.cause, admin: false}
 
     - unless (@listing.closed? && !current_user?(@listing.author)) || !@current_community.listing_comments_in_use
       .view-item

--- a/app/views/people/new.haml
+++ b/app/views/people/new.haml
@@ -81,7 +81,7 @@
         .cause-radio-continer
           = form.radio_button(:cause_id, cause.id, hidden: true, required: true, class: 'cause-radio-button')
           = form.label "cause_id_#{cause.id}", class: 'cause-radio-label' do
-            = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: false}
+            = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: false, is_current_user_viewing: false}
 
     - if @service.has_person_custom_fields?
       - @service.custom_field_values.each_with_index do |custom_field_value, index|

--- a/app/views/people/new.haml
+++ b/app/views/people/new.haml
@@ -81,7 +81,7 @@
         .cause-radio-continer
           = form.radio_button(:cause_id, cause.id, hidden: true, required: true, class: 'cause-radio-button')
           = form.label "cause_id_#{cause.id}", class: 'cause-radio-label' do
-            = render :partial => "layouts/cause_layout", :locals => {cause: cause, edit_cause: false, delete_cause: false}
+            = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: false}
 
     - if @service.has_person_custom_fields?
       - @service.custom_field_values.each_with_index do |custom_field_value, index|

--- a/app/views/people/show.haml
+++ b/app/views/people/show.haml
@@ -35,7 +35,7 @@
     - if @service.person.cause
       .label
         = t('settings.profile.selected_cause')
-      = render :partial => "layouts/cause_layout", :locals => {cause: @service.person.cause, admin: false}
+      = render :partial => "layouts/cause_layout", :locals => {cause: @service.person.cause, admin: false, is_current_user_viewing: (@service.person == @current_user)}
 
 
     - if @service.community_person_custom_fields.any?

--- a/app/views/people/show.haml
+++ b/app/views/people/show.haml
@@ -35,7 +35,7 @@
     - if @service.person.cause
       .label
         = t('settings.profile.selected_cause')
-      = render :partial => "layouts/cause_layout", :locals => {cause: @service.person.cause, edit_cause: false, delete_cause: false}
+      = render :partial => "layouts/cause_layout", :locals => {cause: @service.person.cause, admin: false}
 
 
     - if @service.community_person_custom_fields.any?

--- a/app/views/person_mailer/cause_reset.haml
+++ b/app/views/person_mailer/cause_reset.haml
@@ -1,0 +1,18 @@
+- settings_url = url_for(person_settings_url(I18n.locale, @recipient))
+
+%tr
+  %td.person-name
+    - recipient_name = PersonViewUtils.person_display_name_for_type(@recipient, 'first_name_only')
+    %h1
+      = t("emails.common.hi", name: recipient_name)
+
+%tr
+  %td.email-content
+    %p
+      = t("emails.cause_reset.intro", service: @community_name)
+    %p
+      = t("emails.cause_reset.your_cause_has_changed", service: @community_name, cause_name: @cause_name)
+    %p
+      = t("emails.cause_reset.how_to_select_a_cause", service: @community_name)
+
+= render :partial => "action_button", :locals => { :text => t("emails.cause_reset.settings_button"), :url => settings_url}

--- a/app/views/person_mailer/cause_reset.haml
+++ b/app/views/person_mailer/cause_reset.haml
@@ -1,18 +1,14 @@
 - settings_url = url_for(person_settings_url(I18n.locale, @recipient))
 
 %tr
-  %td.person-name
-    - recipient_name = PersonViewUtils.person_display_name_for_type(@recipient, 'first_name_only')
-    %h1
-      = t("emails.common.hi", name: recipient_name)
-
-%tr
   %td.email-content
     %p
       = t("emails.cause_reset.intro", service: @community_name)
     %p
-      = t("emails.cause_reset.your_cause_has_changed", service: @community_name, cause_name: @cause_name)
+      = t("emails.cause_reset.your_cause_has_changed", service: @community_name, cause_name: @cause_name).html_safe 
     %p
       = t("emails.cause_reset.how_to_select_a_cause", service: @community_name)
+    %p
+      = t("emails.cause_reset.alternatively_click_button")
 
 = render :partial => "action_button", :locals => { :text => t("emails.cause_reset.settings_button"), :url => settings_url}

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -119,7 +119,7 @@
         .cause-radio-continer
           = form.radio_button(:cause_id, cause.id, hidden: true, required: true, class: 'cause-radio-button', checked: (cause.id == current_cause_id ? true : nil))
           = form.label "cause_id_#{cause.id}", class: 'cause-radio-label' do
-            = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: false}
+            = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: false, is_current_user_viewing: (@service.person == @current_user)}
 
 
     - if @service.has_person_custom_fields?

--- a/app/views/settings/show.haml
+++ b/app/views/settings/show.haml
@@ -119,7 +119,7 @@
         .cause-radio-continer
           = form.radio_button(:cause_id, cause.id, hidden: true, required: true, class: 'cause-radio-button', checked: (cause.id == current_cause_id ? true : nil))
           = form.label "cause_id_#{cause.id}", class: 'cause-radio-label' do
-            = render :partial => "layouts/cause_layout", :locals => {cause: cause, edit_cause: false, delete_cause: false}
+            = render :partial => "layouts/cause_layout", :locals => {cause: cause, admin: false}
 
 
     - if @service.has_person_custom_fields?

--- a/app/views/transactions/_details.haml
+++ b/app/views/transactions/_details.haml
@@ -29,7 +29,7 @@
     - unless payment_complete
       = render :partial => "layouts/info_text", :locals => { :text => t(".cause_can_change")}
   - if current_user_cause
-    = render :partial => "layouts/cause_layout", :locals => {cause: current_user_cause, edit_cause: false, delete_cause: false}
+    = render :partial => "layouts/cause_layout", :locals => {cause: current_user_cause, admin: false}
   - else
     = t('.cause_not_selected')
 
@@ -38,7 +38,7 @@
     - unless payment_complete
       = render :partial => "layouts/info_text", :locals => { :text => t(".cause_can_change")}
   - if other_user_cause
-    = render :partial => "layouts/cause_layout", :locals => {cause: other_user_cause, edit_cause: false, delete_cause: false}
+    = render :partial => "layouts/cause_layout", :locals => {cause: other_user_cause, admin: false}
   - else
     = t('.cause_not_selected')
 

--- a/app/views/transactions/_details.haml
+++ b/app/views/transactions/_details.haml
@@ -29,7 +29,7 @@
     - unless payment_complete
       = render :partial => "layouts/info_text", :locals => { :text => t(".cause_can_change")}
   - if current_user_cause
-    = render :partial => "layouts/cause_layout", :locals => {cause: current_user_cause, admin: false}
+    = render :partial => "layouts/cause_layout", :locals => {cause: current_user_cause, admin: false, is_current_user_viewing: true}
   - else
     = t('.cause_not_selected')
 
@@ -38,7 +38,7 @@
     - unless payment_complete
       = render :partial => "layouts/info_text", :locals => { :text => t(".cause_can_change")}
   - if other_user_cause
-    = render :partial => "layouts/cause_layout", :locals => {cause: other_user_cause, admin: false}
+    = render :partial => "layouts/cause_layout", :locals => {cause: other_user_cause, admin: false, is_current_user_viewing: false}
   - else
     = t('.cause_not_selected')
 

--- a/config/config.defaults.yml
+++ b/config/config.defaults.yml
@@ -494,6 +494,8 @@ production: &production_settings
 
   eager_load: true
 
+  asset_host: 'https://gigfunding.org'
+
   log_level: INFO
   stripe_private_key_pattern: "\\Ask_live_.{24,200}\\z"
   stripe_publishable_key_pattern: "\\Apk_live_.{24,200}\\z"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -103,6 +103,11 @@ Rails.application.configure do
     }
   end
 
+  # Serve assets from host
+  config.action_controller.asset_host = APP_CONFIG.asset_host
+  config.action_mailer.asset_host = APP_CONFIG.asset_host
+  config.action_mailer.default_url_options = {host: APP_CONFIG.asset_host }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -136,8 +136,9 @@ Rails.application.configure do
   end
 
   # Serve assets from host
-  config.action_controller.asset_host = "https://gigfunding.org"
-  config.action_mailer.asset_host = config.action_controller.asset_host
+  config.action_controller.asset_host = APP_CONFIG.asset_host
+  config.action_mailer.asset_host = APP_CONFIG.asset_host
+  config.action_mailer.default_url_options = {host: APP_CONFIG.asset_host }
 
   # Sendmail is used for some mails (e.g. Newsletter) so configure it even when smtp is the main method
   if mail_delivery_method == :sendmail

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1208,7 +1208,9 @@ en:
     causes:
       index:
         causes: 'Causes'
+        default_causes: 'Default Cause'
         causes_help: 'Here you can edit the causes which a user will select to donate their gigs to.'
+        default_causes_help: 'This is the default cause which will be selected if a cause is not selected on signup, or causes are deleted or archived.'
         create_a_new_cause: '+ Create a New Cause'
       form:
         name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1854,6 +1854,12 @@ en:
       this_usually_means: "This usually means that there is something blocking the commission from the seller's PayPal account. In most cases the issue is that the seller does not have a valid and verified funding source connected to their PayPal account."
       if_you_would_like_to_investigate: 'If you would like to investigate this further, a good first step is to contact the seller about this.'
       contact_the_seller: 'Contact the seller'
+    cause_reset:
+      subject: 'Please select a new Cause'
+      intro: 'Occasionally at %{service} our Causes change. These changes allow us to bring exciting new partnerships with people doing great work around the world.'
+      your_cause_has_changed: "Unfortunately, your currently selected Cause %{cause_name} has been withdrawn from %{service}. Don't worry, any donations from previous gigs you have paid for or completed will still go to %{cause_name}, we simply need to you select a new Cause from our list of current partners. Until you select a new Cause, the donations of any future gigs you complete will be automatically donated to %{service}."
+      how_to_select_a_cause: "To select a new Cause, please visit %{service}, log in, and navigate to your user settings (top of page user menu 'Settings' button). New Causes can be selected near the bottom of the page and saved by clicking the 'Save information' button. Alternatively, click the link below to visit your user settings."
+      settings_button: "Select a new Cause"
   error_messages:
     booking:
       booking_failed_payment_voided: "Booking failed due to an unexpected error. Please try again later. You haven't been charged."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2328,6 +2328,7 @@ en:
     cause_layout:
         link: "Click here to visit %{cause_name}'s website"
         edit_cause: 'Edit'
+        archive_cause: 'Archive'
         delete_cause: 'Delete'
   listings:
     bubble_listing_not_visible:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1209,8 +1209,10 @@ en:
       index:
         causes: 'Causes'
         default_causes: 'Default Cause'
+        archived_causes: 'Archived Causes'
         causes_help: 'Here you can edit the causes which a user will select to donate their gigs to.'
         default_causes_help: 'This is the default cause which will be selected if a cause is not selected on signup, or causes are deleted or archived.'
+        archived_causes_help: 'These causes are archived and will not be public on the site.'
         create_a_new_cause: '+ Create a New Cause'
       form:
         name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2333,6 +2333,7 @@ en:
         archive_cause: 'Archive'
         unarchive_cause: 'Unarchive'
         delete_cause: 'Delete'
+        edit_person_settings: 'Click here to edit your settings'
   listings:
     bubble_listing_not_visible:
       listing_not_visible: 'You do not have permission to view this listing.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2329,6 +2329,7 @@ en:
         link: "Click here to visit %{cause_name}'s website"
         edit_cause: 'Edit'
         archive_cause: 'Archive'
+        unarchive_cause: 'Unarchive'
         delete_cause: 'Delete'
   listings:
     bubble_listing_not_visible:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1857,8 +1857,9 @@ en:
     cause_reset:
       subject: 'Please select a new Cause'
       intro: 'Occasionally at %{service} our Causes change. These changes allow us to bring exciting new partnerships with people doing great work around the world.'
-      your_cause_has_changed: "Unfortunately, your currently selected Cause %{cause_name} has been withdrawn from %{service}. Don't worry, any donations from previous gigs you have paid for or completed will still go to %{cause_name}, we simply need to you select a new Cause from our list of current partners. Until you select a new Cause, the donations of any future gigs you complete will be automatically donated to %{service}."
-      how_to_select_a_cause: "To select a new Cause, please visit %{service}, log in, and navigate to your user settings (top of page user menu 'Settings' button). New Causes can be selected near the bottom of the page and saved by clicking the 'Save information' button. Alternatively, click the link below to visit your user settings."
+      your_cause_has_changed: "Unfortunately, your currently selected Cause <i>'%{cause_name}'</i> has been withdrawn from %{service}. Don't worry, any donations from previous gigs you have paid for or completed will still go to <i>'%{cause_name}'</i>, we simply need to you select a new Cause from our list of current partners. Until you select a new Cause, the donations of any future gigs you complete will be automatically donated to %{service}."
+      how_to_select_a_cause: "To select a new Cause, please visit %{service}, log in, and navigate to your user settings (top of page user menu 'Settings' button). New Causes can be selected near the bottom of the page and saved by clicking the 'Save information' button."
+      alternatively_click_button: "Alternatively, click the link below to visit your user settings."
       settings_button: "Select a new Cause"
   error_messages:
     booking:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2329,6 +2329,7 @@ en:
       transactions: Transactions
     cause_layout:
         link: "Click here to visit %{cause_name}'s website"
+        default_cause_public: 'Gigfunding'
         edit_cause: 'Edit'
         archive_cause: 'Archive'
         unarchive_cause: 'Unarchive'

--- a/db/migrate/20200917160415_add_default_cause_to_causes.rb
+++ b/db/migrate/20200917160415_add_default_cause_to_causes.rb
@@ -1,0 +1,5 @@
+class AddDefaultCauseToCauses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :causes, :default_cause, :boolean, default: false, not_null: true 
+  end
+end

--- a/db/migrate/20200917173642_add_archived_to_causes.rb
+++ b/db/migrate/20200917173642_add_archived_to_causes.rb
@@ -1,0 +1,5 @@
+class AddArchivedToCauses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :causes, :archived, :boolean, default: false
+  end
+end

--- a/db/migrate/20200917220120_add_deleted_to_causes.rb
+++ b/db/migrate/20200917220120_add_deleted_to_causes.rb
@@ -1,0 +1,5 @@
+class AddDeletedToCauses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :causes, :deleted, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -195,6 +195,7 @@ CREATE TABLE `causes` (
   `logo_file_size` int DEFAULT NULL,
   `logo_updated_at` datetime DEFAULT NULL,
   `community_id` bigint DEFAULT NULL,
+  `default_cause` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_causes_on_community_id` (`community_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -2510,6 +2511,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200904221930'),
 ('20200905121501'),
 ('20200905165457'),
-('20200905200905');
+('20200905200905'),
+('20200917160415');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -197,6 +197,7 @@ CREATE TABLE `causes` (
   `community_id` bigint DEFAULT NULL,
   `default_cause` tinyint(1) DEFAULT '0',
   `archived` tinyint(1) DEFAULT '0',
+  `deleted` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_causes_on_community_id` (`community_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -2514,6 +2515,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200905165457'),
 ('20200905200905'),
 ('20200917160415'),
-('20200917173642');
+('20200917173642'),
+('20200917220120');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -196,6 +196,7 @@ CREATE TABLE `causes` (
   `logo_updated_at` datetime DEFAULT NULL,
   `community_id` bigint DEFAULT NULL,
   `default_cause` tinyint(1) DEFAULT '0',
+  `archived` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_causes_on_community_id` (`community_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -2512,6 +2513,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200905121501'),
 ('20200905165457'),
 ('20200905200905'),
-('20200917160415');
+('20200917160415'),
+('20200917173642');
 
 

--- a/spec/controllers/admin/community_customizations_controller_spec.rb
+++ b/spec/controllers/admin/community_customizations_controller_spec.rb
@@ -45,7 +45,7 @@ describe Admin::CommunityCustomizationsController, type: :controller do
         update_typed_slogans_params = {"#{@typed_slogan1.id}": {"typed_slogan_text": "test1"}, "#{@typed_slogan2.id}": {"typed_slogan_text": "test2"}}
         full_post_params = {"new_typed_slogans": new_typed_slogan_params, "update_typed_slogans": update_typed_slogans_params, "community_customizations": community_customizations_params}
 
-        expect{post :update_details, params: full_post_params}.to change{TypedSlogan.all.length}.from(2).to(3)
+        expect{post :update_details, params: full_post_params}.to(change{TypedSlogan.all.length}).from(2).to(3)
         expect(TypedSlogan.last.typed_slogan_text).to eq('new typed slogan')
       end
 
@@ -54,7 +54,7 @@ describe Admin::CommunityCustomizationsController, type: :controller do
         update_typed_slogans_params = {"#{@typed_slogan1.id}": {"typed_slogan_text": "test1"}, "#{@typed_slogan2.id}": {"typed_slogan_text": "test2"}}
         full_post_params = {"new_typed_slogans": new_typed_slogan_params, "update_typed_slogans": update_typed_slogans_params, "community_customizations": community_customizations_params}
 
-        expect{post :update_details, params: full_post_params}.to_not change{TypedSlogan.all.length}
+        expect{post :update_details, params: full_post_params}.to_not(change{TypedSlogan.all.length})
       end
 
       it 'ignores new typed_slogans if ignore key passed' do
@@ -62,7 +62,7 @@ describe Admin::CommunityCustomizationsController, type: :controller do
         update_typed_slogans_params = {"#{@typed_slogan1.id}": {"typed_slogan_text": "test1"}, "#{@typed_slogan2.id}": {"typed_slogan_text": "test2"}}
         full_post_params = {"new_typed_slogans": new_typed_slogan_params, "update_typed_slogans": update_typed_slogans_params, "community_customizations": community_customizations_params}
 
-        expect{post :update_details, params: full_post_params}.to_not change{TypedSlogan.all.length}
+        expect{post :update_details, params: full_post_params}.to_not(change{TypedSlogan.all.length})
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -561,5 +561,6 @@ FactoryGirl.define do
     description 'description of cause'
     link 'http://example.com'
     default_cause true
+    archived false
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -126,11 +126,11 @@ FactoryGirl.define do
     title "Sledgehammer"
     description("test")
     build_association(:author)
+    build_association(:listing_shape)
     category { TestHelpers::find_or_build_category("item") }
     valid_until { Time.current + 3.months }
     times_viewed 0
     privacy "public"
-    listing_shape_id 123
     shape_name_tr_key "admin.listing_shapes.listing_shape_name"
     price Money.new(20, "USD")
     uuid
@@ -474,7 +474,6 @@ FactoryGirl.define do
     kind                'time'
     name_tr_key         nil
     selector_tr_key     nil
-    listing_shape_id    123
   end
 
   factory :invitation_unsubscribe, class: 'Invitation::Unsubscribe' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -559,5 +559,6 @@ FactoryGirl.define do
     name 'Name of cause'
     description 'description of cause'
     link 'http://example.com'
+    default_cause true
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -53,12 +53,6 @@ class FactoryGirl::DefinitionProxy
 end
 
 FactoryGirl.define do
-  factory :cause do
-    name 'Name of cause'
-    description 'description of cause'
-    link 'http://example.com'
-  end
-
   sequence :id do |_|
     SecureRandom.urlsafe_base64
   end
@@ -558,5 +552,12 @@ FactoryGirl.define do
     community_id 999
     locale 'en'
     typed_slogan_text 'some typed slogan text'
+  end
+
+  factory :cause do
+    community_id 999
+    name 'Name of cause'
+    description 'description of cause'
+    link 'http://example.com'
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -101,6 +101,7 @@ FactoryGirl.define do
     username
     password "testi"
     deleted 0
+    build_association(:cause)
 
     has_many :emails do |person|
       FactoryGirl.build(:email, person: person)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -562,5 +562,6 @@ FactoryGirl.define do
     link 'http://example.com'
     default_cause true
     archived false
+    deleted false
   end
 end

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -51,7 +51,7 @@ describe PersonMailer, type: :mailer do
 
     assert !ActionMailer::Base.deliveries.empty?
     assert_equal recipient.confirmed_notification_email_addresses, email.to
-    assert_equal "Remember to add your payment details to receive payments", email.subject
+    assert_equal "You need to add your details to be verified", email.subject
   end
 
   describe "status changed" do

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -243,4 +243,15 @@ describe PersonMailer, type: :mailer do
       expect(email.body).to have_text("Proto has marked the order <b>Sledgehammer</b> completed. The payment for this transaction has now been released. You can now give feedback to Proto.")
     end
   end
+
+  describe '#reset_cause' do
+    it "cause is displayed in email" do
+      cause = FactoryGirl.create(:cause, community: @community)
+      email = MailCarrier.deliver_now(PersonMailer.cause_reset(@test_person, cause, @community))
+      assert !ActionMailer::Base.deliveries.empty?
+      assert_equal @test_person.confirmed_notification_email_addresses, email.to
+      assert_equal "Please select a new Cause", email.subject
+      expect(email).to have_body_text(cause.name)
+    end
+  end
 end

--- a/spec/models/cause_spec.rb
+++ b/spec/models/cause_spec.rb
@@ -15,6 +15,7 @@
 #  community_id      :bigint
 #  default_cause     :boolean          default(FALSE)
 #  archived          :boolean          default(FALSE)
+#  deleted           :boolean          default(FALSE)
 #
 # Indexes
 #
@@ -25,7 +26,7 @@ require 'spec_helper'
 
 RSpec.describe Cause, type: :model do
   let(:community) { FactoryGirl.create(:community) }
-  let(:cause) { FactoryGirl.create(:cause, community: community) }
+  let(:cause) { FactoryGirl.create(:cause, community: community, default_cause: false) }
 
   context 'name validations' do
     it 'is present' do
@@ -102,6 +103,23 @@ RSpec.describe Cause, type: :model do
       normal_cause.archived = true
       normal_cause.save
       expect(person.reload.cause.default_cause).to eq(true)
+    end
+
+    it "cause deleted" do
+      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
+      person = FactoryGirl.create(:person, cause_id: normal_cause.id)
+      normal_cause.deleted = true
+      normal_cause.save
+      expect(person.reload.cause.default_cause).to eq(true)
+    end
+  end
+
+  context 'paranoid deletes' do
+    it 'cause is deleted' do
+      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
+      normal_cause.deleted = true
+      normal_cause.save
+      expect(Cause.available.where(name: normal_cause.name).length).to eq(0)
     end
   end
 end

--- a/spec/models/cause_spec.rb
+++ b/spec/models/cause_spec.rb
@@ -87,4 +87,23 @@ RSpec.describe Cause, type: :model do
       expect(cause).to_not be_valid
     end
   end
+
+  context 'apply default cause to persons' do
+    it "cause deleted" do
+      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
+      person = FactoryGirl.create(:person, cause_id: normal_cause.id)
+      normal_cause.destroy
+      expect(person.reload.cause.default_cause).to eq(true)
+    end
+
+    it "cause archived" do
+      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
+      person = FactoryGirl.create(:person, cause_id: normal_cause.id)
+      normal_cause.archived = true
+      normal_cause.save
+      expect(person.reload.cause.default_cause).to eq(true)
+    end
+  end
 end
+
+

--- a/spec/models/cause_spec.rb
+++ b/spec/models/cause_spec.rb
@@ -90,36 +90,46 @@ RSpec.describe Cause, type: :model do
   end
 
   context 'apply default cause to persons' do
-    it "cause deleted" do
-      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
-      person = FactoryGirl.create(:person, cause_id: normal_cause.id)
-      normal_cause.destroy
-      expect(person.reload.cause.default_cause).to eq(true)
+    before(:each) do
+      @normal_cause = FactoryGirl.create(:cause, community: community, name: 'another cause', default_cause: false)
+      @person = FactoryGirl.create(:person, cause_id: @normal_cause.id)
+    end
+
+    it "cause destroyed" do
+      @normal_cause.destroy
+      expect(@person.reload.cause.default_cause).to eq(true)
     end
 
     it "cause archived" do
-      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
-      person = FactoryGirl.create(:person, cause_id: normal_cause.id)
-      normal_cause.archived = true
-      normal_cause.save
-      expect(person.reload.cause.default_cause).to eq(true)
+      @normal_cause.archived = true
+      @normal_cause.save
+      expect(@person.reload.cause.default_cause).to eq(true)
     end
 
     it "cause deleted" do
-      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
-      person = FactoryGirl.create(:person, cause_id: normal_cause.id)
-      normal_cause.deleted = true
-      normal_cause.save
-      expect(person.reload.cause.default_cause).to eq(true)
+      @normal_cause.deleted = true
+      @normal_cause.save
+      expect(@person.reload.cause.default_cause).to eq(true)
     end
   end
 
   context 'paranoid deletes' do
     it 'cause is deleted' do
-      normal_cause = FactoryGirl.create(:cause, name: 'another cause', default_cause: false)
+      normal_cause = FactoryGirl.create(:cause, community: community, name: 'another cause', default_cause: false)
       normal_cause.deleted = true
       normal_cause.save
       expect(Cause.available.where(name: normal_cause.name).length).to eq(0)
+    end
+  end
+
+  context 'person notifications' do
+    it 'cause reset' do
+      normal_cause = FactoryGirl.create(:cause, community: community, name: 'another cause', default_cause: false)
+      person = FactoryGirl.create(:person, community: community, cause_id: normal_cause.id)
+      expect(Delayed::Job).to receive(:enqueue)
+      expect(CauseResetJob).to receive(:new).with(person.id, normal_cause.id, community.id)
+      normal_cause.deleted = true
+      normal_cause.save
     end
   end
 end

--- a/spec/models/cause_spec.rb
+++ b/spec/models/cause_spec.rb
@@ -13,6 +13,7 @@
 #  logo_file_size    :integer
 #  logo_updated_at   :datetime
 #  community_id      :bigint
+#  default_cause     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/cause_spec.rb
+++ b/spec/models/cause_spec.rb
@@ -14,6 +14,7 @@
 #  logo_updated_at   :datetime
 #  community_id      :bigint
 #  default_cause     :boolean          default(FALSE)
+#  archived          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -380,4 +380,22 @@ describe Person, type: :model do
 
     end
   end
+
+  describe "assign default cause" do
+    # let(:another_cause) { FactoryGirl.create(:cause, name: 'another cause', default_cause: false) }
+
+    it "no cause on creation" do
+      person = FactoryGirl.create(:person)
+      ap person.cause
+      expect(person.cause).to_not eq(nil)
+    end
+
+    # it "cause deleted" do
+    #   person = FactoryGirl.create(:person, cause_id: another_cause.id)
+    #   expect(person.cause).to eq(another_cause)
+    #   another_cause.destroy
+    #   ap person.cause
+    #   expect(person.cause.default_cause).to eq(true)
+    # end
+  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -382,20 +382,18 @@ describe Person, type: :model do
   end
 
   describe "assign default cause" do
-    # let(:another_cause) { FactoryGirl.create(:cause, name: 'another cause', default_cause: false) }
+    let(:another_cause) { FactoryGirl.create(:cause, name: 'another cause', default_cause: false) }
 
     it "no cause on creation" do
       person = FactoryGirl.create(:person)
-      ap person.cause
       expect(person.cause).to_not eq(nil)
     end
 
-    # it "cause deleted" do
-    #   person = FactoryGirl.create(:person, cause_id: another_cause.id)
-    #   expect(person.cause).to eq(another_cause)
-    #   another_cause.destroy
-    #   ap person.cause
-    #   expect(person.cause.default_cause).to eq(true)
-    # end
+    it "cause deleted" do
+      person = FactoryGirl.create(:person, cause_id: another_cause.id)
+      expect(person.cause).to eq(another_cause)
+      another_cause.destroy
+      expect(person.reload.cause.default_cause).to eq(true)
+    end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -382,18 +382,9 @@ describe Person, type: :model do
   end
 
   describe "assign default cause" do
-    let(:another_cause) { FactoryGirl.create(:cause, name: 'another cause', default_cause: false) }
-
     it "no cause on creation" do
-      person = FactoryGirl.create(:person)
+      person = FactoryGirl.create(:person, cause_id: nil)
       expect(person.cause).to_not eq(nil)
-    end
-
-    it "cause deleted" do
-      person = FactoryGirl.create(:person, cause_id: another_cause.id)
-      expect(person.cause).to eq(another_cause)
-      another_cause.destroy
-      expect(person.reload.cause.default_cause).to eq(true)
     end
   end
 end


### PR DESCRIPTION
**Task:** https://www.wrike.com/open.htm?id=512262652
**Issue:** Edge cases related to cause resource creation
**Changes:**
- Fix rspec tests
- Add default cause template and column to cause model
- Default cause created from template on community creation
- User assigned to default cause if their selected cause is deleted, or they signup without a cause (Social signup)
- Causes can be archived instead of deleted, allowing for continuity of transactions causes when charities leave partnership
- Message to user to select cause if not selected
- Paranoid deletes on causes
- Email on cause_reset to people who have it selected (delayed_job)

**Deploy:**
- add default cause to all communities using:
``` sh
rails c 
```
```ruby
Community.all.each do |community|
  cause_params = Cause::DEFAULT
  cause_params[:community_id] = community.id
  Cause.create(cause_params)
end
```
- assign default cause to any users which do not already have a cause
```sh
rails c
```
```ruby
default_cause = Cause.find_by(default_cause: true)
Person.where(cause_id: nil).update_all(cause_id: default_cause.id)
```
- recompile assets
- restart application server