### PR TITLE
Automatic Transaction Acceptance

### DIFF
--- a/app/assets/stylesheets/partials/_forms.scss
+++ b/app/assets/stylesheets/partials/_forms.scss
@@ -76,7 +76,7 @@ input.auto_width {
 }
 
 .check-box-label {
-  width: fit-content;
+  width: auto;
   margin: 0;
   padding-right: 8px;
   margin-top: 5px;

--- a/app/assets/stylesheets/partials/_forms.scss
+++ b/app/assets/stylesheets/partials/_forms.scss
@@ -67,3 +67,21 @@ input.auto_width {
     float: right;
   }
 }
+
+.inline-checkbox-container {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 1em 0;
+}
+
+.check-box-label {
+  width: fit-content;
+  margin: 0;
+  padding-right: 8px;
+  margin-top: 5px;
+}
+
+.check-box {
+  margin-top: 5px;
+}

--- a/app/assets/stylesheets/views/_preauthorize.scss
+++ b/app/assets/stylesheets/views/_preauthorize.scss
@@ -13,7 +13,7 @@
   margin-bottom: lines(0.25);
 }
 
-.you_will_be_charged_notice {
+.you-will-be-charged-notice {
   @include small-type;
   font-style: italic;
 }

--- a/app/controllers/accept_preauthorized_conversations_controller.rb
+++ b/app/controllers/accept_preauthorized_conversations_controller.rb
@@ -1,4 +1,5 @@
 class AcceptPreauthorizedConversationsController < ApplicationController
+  include AcceptRejectTransaction
 
   before_action do |controller|
     controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_accept_or_reject")
@@ -90,26 +91,6 @@ class AcceptPreauthorizedConversationsController < ApplicationController
     else
       {flow: :unknown, success: false}
     end
-  end
-
-  def accept_tx(community_id, tx_id, message, sender_id)
-    TransactionService::Transaction.complete_preauthorization(community_id: community_id,
-                                                              transaction_id: tx_id,
-                                                              message: message,
-                                                              sender_id: sender_id)
-      .maybe()
-      .map { |_| {flow: :accept, success: true}}
-      .or_else({flow: :accept, success: false})
-  end
-
-  def reject_tx(community_id, tx_id, message, sender_id)
-    TransactionService::Transaction.reject(community_id: community_id,
-                                           transaction_id: tx_id,
-                                           message: message,
-                                           sender_id: sender_id)
-      .maybe()
-      .map { |_| {flow: :reject, success: true}}
-      .or_else({flow: :reject, success: false})
   end
 
   def success_msg(flow)

--- a/app/controllers/concerns/accept_reject_transaction.rb
+++ b/app/controllers/concerns/accept_reject_transaction.rb
@@ -1,7 +1,7 @@
 module AcceptRejectTransaction
   extend ActiveSupport::Concern
 
-  def accept_tx(community_id, tx_id, message, sender_id)
+  def accept_tx(community_id, tx_id, message = nil, sender_id = nil)
     TransactionService::Transaction.complete_preauthorization(community_id: community_id,
                                                               transaction_id: tx_id,
                                                               message: message,
@@ -11,7 +11,7 @@ module AcceptRejectTransaction
       .or_else({flow: :accept, success: false})
   end
 
-  def reject_tx(community_id, tx_id, message, sender_id)
+  def reject_tx(community_id, tx_id, message = nil, sender_id = nil)
     TransactionService::Transaction.reject(community_id: community_id,
                                            transaction_id: tx_id,
                                            message: message,

--- a/app/controllers/concerns/accept_reject_transaction.rb
+++ b/app/controllers/concerns/accept_reject_transaction.rb
@@ -1,0 +1,23 @@
+module AcceptRejectTransaction
+  extend ActiveSupport::Concern
+
+  def accept_tx(community_id, tx_id, message, sender_id)
+    TransactionService::Transaction.complete_preauthorization(community_id: community_id,
+                                                              transaction_id: tx_id,
+                                                              message: message,
+                                                              sender_id: sender_id)
+      .maybe()
+      .map { |_| {flow: :accept, success: true}}
+      .or_else({flow: :accept, success: false})
+  end
+
+  def reject_tx(community_id, tx_id, message, sender_id)
+    TransactionService::Transaction.reject(community_id: community_id,
+                                           transaction_id: tx_id,
+                                           message: message,
+                                           sender_id: sender_id)
+      .maybe()
+      .map { |_| {flow: :reject, success: true}}
+      .or_else({flow: :reject, success: false})
+  end
+end

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -435,7 +435,7 @@ class PreauthorizeTransactionsController < ApplicationController
         old_free_transaction = transactions_for_conversation.detect {|transaction| transaction.current_state == 'free'}
         old_free_transaction&.destroy
       end
-      automatic_transaction_confirmation(tx_response[:data][:transaction])
+      process_automatic_transaction_confirmation(tx_response[:data][:transaction])
     end
 
     handle_tx_response(tx_response, params[:payment_type].to_sym)
@@ -475,13 +475,15 @@ class PreauthorizeTransactionsController < ApplicationController
     end
   end
 
-  def automatic_transaction_confirmation(transaction_struct)
-    accept_tx(transaction_struct[:community_id], transaction_struct[:id])
-    record_event(
-        { notice: t("layouts.notifications.request_accepted") },
-        "PreauthorizedTransactionAccepted",
-        { listing_id: transaction_struct[:listing_id],
-          listing_uuid: UUIDUtils.parse_raw(transaction_struct[:listing_uuid]).to_s,
-          transaction_id: transaction_struct[:id] })
+  def process_automatic_transaction_confirmation(transaction_struct)
+    if listing.automatically_confirm
+      accept_tx(transaction_struct[:community_id], transaction_struct[:id])
+      record_event(
+          { notice: t("layouts.notifications.request_accepted") },
+          "PreauthorizedTransactionAccepted",
+          { listing_id: transaction_struct[:listing_id],
+            listing_uuid: UUIDUtils.parse_raw(transaction_struct[:listing_uuid]).to_s,
+            transaction_id: transaction_struct[:id] })
+    end
   end
 end

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -1,4 +1,5 @@
 class PreauthorizeTransactionsController < ApplicationController
+  include AcceptRejectTransaction
 
   before_action do |controller|
    controller.ensure_logged_in t("layouts.notifications.you_must_log_in_to_do_a_transaction")
@@ -436,6 +437,7 @@ class PreauthorizeTransactionsController < ApplicationController
         old_free_transaction = transactions_for_conversation.detect {|transaction| transaction.current_state == 'free'}
         old_free_transaction&.destroy
       end
+      automatic_transaction_confirmation(tx_response[:data][:transaction])
     end
 
     handle_tx_response(tx_response, params[:payment_type].to_sym)
@@ -473,5 +475,9 @@ class PreauthorizeTransactionsController < ApplicationController
     else
       t("error_messages.#{gateway}.generic_error")
     end
+  end
+
+  def automatic_transaction_confirmation(transaction_struct)
+    accept_tx(transaction_struct[:community_id], transaction_struct[:id])
   end
 end

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -31,8 +31,6 @@ class PreauthorizeTransactionsController < ApplicationController
         stripe_in_use: StripeHelper.user_and_community_ready_for_payments?(listing.author_id, @current_community.id))
     }
 
-
-
     if validation_result.success
       initiation_success(validation_result.data)
     else
@@ -479,5 +477,11 @@ class PreauthorizeTransactionsController < ApplicationController
 
   def automatic_transaction_confirmation(transaction_struct)
     accept_tx(transaction_struct[:community_id], transaction_struct[:id])
+    record_event(
+        { notice: t("layouts.notifications.request_accepted") },
+        "PreauthorizedTransactionAccepted",
+        { listing_id: transaction_struct[:listing_id],
+          listing_uuid: UUIDUtils.parse_raw(transaction_struct[:listing_uuid]).to_s,
+          transaction_id: transaction_struct[:id] })
   end
 end

--- a/app/controllers/preauthorize_transactions_controller.rb
+++ b/app/controllers/preauthorize_transactions_controller.rb
@@ -435,7 +435,7 @@ class PreauthorizeTransactionsController < ApplicationController
         old_free_transaction = transactions_for_conversation.detect {|transaction| transaction.current_state == 'free'}
         old_free_transaction&.destroy
       end
-      process_automatic_transaction_confirmation(tx_response[:data][:transaction])
+      process_automatic_payment_acceptance(tx_response[:data][:transaction])
     end
 
     handle_tx_response(tx_response, params[:payment_type].to_sym)
@@ -475,8 +475,8 @@ class PreauthorizeTransactionsController < ApplicationController
     end
   end
 
-  def process_automatic_transaction_confirmation(transaction_struct)
-    if listing.automatically_confirm
+  def process_automatic_payment_acceptance(transaction_struct)
+    if listing.automatically_accept_payment
       accept_tx(transaction_struct[:community_id], transaction_struct[:id])
       record_event(
           { notice: t("layouts.notifications.request_accepted") },

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -187,6 +187,7 @@ class Listing < ApplicationRecord
   validates_presence_of :category
   validates_inclusion_of :valid_until, :allow_nil => true, :in => proc{ DateTime.now..DateTime.now + 7.months }
   validates_numericality_of :price_cents, :only_integer => true, :greater_than_or_equal_to => 0, :message => "price must be numeric", :allow_nil => true
+  validate :automatic_confirmation_validation
 
   # sets the time to midnight
   def set_valid_until_time
@@ -392,5 +393,14 @@ class Listing < ApplicationRecord
     end
     ids = listings.pluck(:id)
     ListingImage.where(listing_id: ids).destroy_all
+  end
+
+  private
+
+  def automatic_confirmation_validation
+    transaction_process = TransactionProcess.find(transaction_process_id)
+    if automatically_confirm && ( listing_shape.requesting_type? || transaction_process.process != :preauthorize )
+      errors.add(:automatically_confirm, 'invalid listing type for automatic confirmation')
+    end
   end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -49,7 +49,7 @@
 #  per_hour_ready                  :boolean          default(FALSE)
 #  state                           :string(255)      default("approved")
 #  approval_count                  :integer          default(0)
-#  automatically_confirm           :boolean          default(FALSE)
+#  automatically_accept_payment    :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -187,7 +187,7 @@ class Listing < ApplicationRecord
   validates_presence_of :category
   validates_inclusion_of :valid_until, :allow_nil => true, :in => proc{ DateTime.now..DateTime.now + 7.months }
   validates_numericality_of :price_cents, :only_integer => true, :greater_than_or_equal_to => 0, :message => "price must be numeric", :allow_nil => true
-  validate :automatic_confirmation_validation
+  validate :automatic_payment_acceptance_validation
 
   # sets the time to midnight
   def set_valid_until_time
@@ -397,10 +397,10 @@ class Listing < ApplicationRecord
 
   private
 
-  def automatic_confirmation_validation
+  def automatic_payment_acceptance_validation
     transaction_process = TransactionProcess.find(transaction_process_id)
-    if automatically_confirm && ( listing_shape.requesting_type? || transaction_process.process != :preauthorize )
-      errors.add(:automatically_confirm, 'invalid listing type for automatic confirmation')
+    if automatically_accept_payment && ( listing_shape.requesting_type? || transaction_process.process != :preauthorize )
+      errors.add(:automatically_accept_payment, 'invalid listing type for automatic payment acceptance')
     end
   end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -49,6 +49,7 @@
 #  per_hour_ready                  :boolean          default(FALSE)
 #  state                           :string(255)      default("approved")
 #  approval_count                  :integer          default(0)
+#  automatically_confirm           :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -399,7 +399,7 @@ class Listing < ApplicationRecord
 
   def automatic_payment_acceptance_validation
     transaction_process = TransactionProcess.find(transaction_process_id)
-    if automatically_accept_payment && ( listing_shape.requesting_type? || transaction_process.process != :preauthorize )
+    if automatically_accept_payment && (listing_shape.requesting_type? || transaction_process.process != :preauthorize)
       errors.add(:automatically_accept_payment, 'invalid listing type for automatic payment acceptance')
     end
   end

--- a/app/models/listing_shape.rb
+++ b/app/models/listing_shape.rb
@@ -219,4 +219,8 @@ class ListingShape < ApplicationRecord
   def type_selection_label
     type_selection_label_tr_key&.present? ? I18n.t(type_selection_label_tr_key) : "Make a '#{I18n.t(name_tr_key)}' type listing"
   end
+
+  def requesting_type?
+    name == 'requesting'
+  end
 end

--- a/app/views/listing_conversations/_stripe_payment.haml
+++ b/app/views/listing_conversations/_stripe_payment.haml
@@ -4,7 +4,7 @@
     .col-12
       %h3
         = t(".pay_with_card")
-  = render :partial => "listing_conversations/you_will_be_charged_notice", locals: { author_link: author_link, paypal_expiration_period: paypal_expiration_period }
+  = render :partial => "listing_conversations/you_will_be_charged_notice", locals: { author_link: author_link, paypal_expiration_period: paypal_expiration_period, listing: listing }
 
 .form-row
   .row

--- a/app/views/listing_conversations/_you_will_be_charged_notice.haml
+++ b/app/views/listing_conversations/_you_will_be_charged_notice.haml
@@ -1,4 +1,4 @@
-- unless listing.automatically_confirm
+- unless listing.automatically_accept_payment
   .row
     .col-12
       %p.you-will-be-charged-notice

--- a/app/views/listing_conversations/_you_will_be_charged_notice.haml
+++ b/app/views/listing_conversations/_you_will_be_charged_notice.haml
@@ -1,4 +1,5 @@
-.row
-  .col-12
-    %p.you_will_be_charged_notice
-      = t("listing_conversations.preauthorize.you_will_be_charged", author: author_link, expiration_period: paypal_expiration_period).html_safe
+- unless listing.automatically_confirm
+  .row
+    .col-12
+      %p.you-will-be-charged-notice
+        = t("listing_conversations.preauthorize.you_will_be_charged", author: author_link, expiration_period: paypal_expiration_period).html_safe

--- a/app/views/listing_conversations/initiate.haml
+++ b/app/views/listing_conversations/initiate.haml
@@ -62,7 +62,7 @@
           .col-12
             %h2
               = t("listing_conversations.stripe_payment.payment")  
-        = render :partial => "listing_conversations/stripe_payment", locals: {  publishable_key: stripe_publishable_key, stripe_shipping_required: stripe_shipping_required, paypal_in_use: paypal_in_use, author_link: author_link, paypal_expiration_period: paypal_expiration_period}
+        = render :partial => "listing_conversations/stripe_payment", locals: {  publishable_key: stripe_publishable_key, stripe_shipping_required: stripe_shipping_required, paypal_in_use: paypal_in_use, author_link: author_link, paypal_expiration_period: paypal_expiration_period, listing: listing} 
 
       - if paypal_in_use && !stripe_in_use
         .row
@@ -82,7 +82,7 @@
               = image_tag 'checkout_with_paypal.png'
 
       - if stripe_in_use || paypal_in_use
-        = render :partial => "listing_conversations/you_will_be_charged_notice", locals: { author_link: author_link, paypal_expiration_period: paypal_expiration_period }
+        = render :partial => "listing_conversations/you_will_be_charged_notice", locals: { author_link: author_link, paypal_expiration_period: paypal_expiration_period, listing: listing }
 
   %noscript
     = "For security reasons JavaScript has to be enabled"

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -64,5 +64,5 @@
 
 - if @listing_presenter.shape[:price_enabled] && payment_gateway.present? && !@listing_presenter.shape.requesting_type?
   .inline-checkbox-container
-    = form.label(:automatically_confirm, "#{t('.automatically_confirm')}:", :class => "check-box-label")
-    = form.check_box(:automatically_confirm, :class => "check-box")
+    = form.label(:automatically_accept_payment, "#{t('.automatically_accept_payment')}:", :class => "check-box-label")
+    = form.check_box(:automatically_accept_payment, :class => "check-box")

--- a/app/views/listings/form/_price.haml
+++ b/app/views/listings/form/_price.haml
@@ -61,3 +61,8 @@
     - content_for :extra_javascript do
       :javascript
         $('#payment_fee_info_link').click(function() { $('#payment_fee_info_content').lightbox_me({centered: true, zIndex: 1000000}); ; return false});
+
+- if @listing_presenter.shape[:price_enabled] && payment_gateway.present? && !@listing_presenter.shape.requesting_type?
+  .inline-checkbox-container
+    = form.label(:automatically_confirm, "#{t('.automatically_confirm')}:", :class => "check-box-label")
+    = form.check_box(:automatically_confirm, :class => "check-box")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2512,6 +2512,7 @@ en:
         shipping_price: 'Shipping fee'
         shipping_price_additional: 'Additional items'
         pickup: Pickup
+        automatically_confirm: Automatically confirm payments
       origin:
         location: Location
         origin: Origin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2512,7 +2512,7 @@ en:
         shipping_price: 'Shipping fee'
         shipping_price_additional: 'Additional items'
         pickup: Pickup
-        automatically_confirm: Automatically confirm payments
+        automatically_accept_payment: Automatically confirm payments
       origin:
         location: Location
         origin: Origin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2512,7 +2512,7 @@ en:
         shipping_price: 'Shipping fee'
         shipping_price_additional: 'Additional items'
         pickup: Pickup
-        automatically_accept_payment: Automatically confirm payments
+        automatically_accept_payment: Automatically accept payments
       origin:
         location: Location
         origin: Origin

--- a/db/migrate/20210303190135_add_automatically_confirm_to_listing.rb
+++ b/db/migrate/20210303190135_add_automatically_confirm_to_listing.rb
@@ -1,0 +1,5 @@
+class AddAutomaticallyConfirmToListing < ActiveRecord::Migration[5.2]
+  def change
+    add_column :listings, :automatically_confirm, :boolean, default: false
+  end
+end

--- a/db/migrate/20210303204204_rename_listing_column_name_automatically_confirm.rb
+++ b/db/migrate/20210303204204_rename_listing_column_name_automatically_confirm.rb
@@ -1,0 +1,5 @@
+class RenameListingColumnNameAutomaticallyConfirm < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :listings, :automatically_confirm, :automatically_accept_payment
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -929,6 +929,7 @@ CREATE TABLE `listings` (
   `per_hour_ready` tinyint(1) DEFAULT '0',
   `state` varchar(255) DEFAULT 'approved',
   `approval_count` int DEFAULT '0',
+  `automatically_confirm` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_listings_on_uuid` (`uuid`),
   KEY `index_listings_on_new_category_id` (`category_id`) USING BTREE,
@@ -2546,6 +2547,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20201117190309'),
 ('20201218155820'),
 ('20201218194339'),
-('20201218202236');
+('20201218202236'),
+('20210303190135');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -929,7 +929,7 @@ CREATE TABLE `listings` (
   `per_hour_ready` tinyint(1) DEFAULT '0',
   `state` varchar(255) DEFAULT 'approved',
   `approval_count` int DEFAULT '0',
-  `automatically_confirm` tinyint(1) DEFAULT '0',
+  `automatically_accept_payment` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_listings_on_uuid` (`uuid`),
   KEY `index_listings_on_new_category_id` (`category_id`) USING BTREE,
@@ -2548,6 +2548,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20201218155820'),
 ('20201218194339'),
 ('20201218202236'),
-('20210303190135');
+('20210303190135'),
+('20210303204204');
 
 

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -49,7 +49,7 @@
 #  per_hour_ready                  :boolean          default(FALSE)
 #  state                           :string(255)      default("approved")
 #  approval_count                  :integer          default(0)
-#  automatically_confirm           :boolean          default(FALSE)
+#  automatically_accept_payment    :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -49,6 +49,7 @@
 #  per_hour_ready                  :boolean          default(FALSE)
 #  state                           :string(255)      default("approved")
 #  approval_count                  :integer          default(0)
+#  automatically_confirm           :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -49,7 +49,7 @@
 #  per_hour_ready                  :boolean          default(FALSE)
 #  state                           :string(255)      default("approved")
 #  approval_count                  :integer          default(0)
-#  automatically_confirm           :boolean          default(FALSE)
+#  automatically_accept_payment    :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -49,6 +49,7 @@
 #  per_hour_ready                  :boolean          default(FALSE)
 #  state                           :string(255)      default("approved")
 #  approval_count                  :integer          default(0)
+#  automatically_confirm           :boolean          default(FALSE)
 #
 # Indexes
 #


### PR DESCRIPTION
**Issue:** some transactions require payment accepting automatically
**Changes:**
- Extract accept and reject transactions methods out of AcceptPreauthorizedConversationsController into controller concern AcceptRejectTransaction
- Add flag (attribute) on listing model to automatically accept payment: flag only allowed if listing has payment process of ':preauthorize' and is not a requesting listing
- Add check box to listing new and edit forms to enable automatic payment acceptance
- Mixin AcceptRejectTransaction to PreauthorizeTransactionsController and run if automatically accept payment if flagged, also record additional GA event
- Update text on transaction flow to remove notices of payment authorization on listings which payment will confirm automatically

**Deploy:**
- rails db:migrate
- recompile client assets
- restart app server